### PR TITLE
Return Passport tokens after OTP verification

### DIFF
--- a/Modules/Auth/app/Http/Controllers/Api/MobileAuthController.php
+++ b/Modules/Auth/app/Http/Controllers/Api/MobileAuthController.php
@@ -1,0 +1,227 @@
+<?php
+
+namespace Modules\Auth\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\User;
+use App\Support\ApiResponse;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\RateLimiter;
+use Illuminate\Support\Str;
+use Laravel\Passport\Passport;
+use Modules\Auth\Http\Requests\SendOtpRequest;
+use Modules\Auth\Http\Requests\VerifyOtpRequest;
+use Modules\Auth\Http\Resources\ProfileResource;
+use Modules\Auth\Jobs\SendSmsMessage;
+use Modules\Auth\Models\Otp;
+use RuntimeException;
+use Symfony\Component\HttpFoundation\Response;
+
+class MobileAuthController extends Controller
+{
+    private const OTP_LENGTH = 6;
+    private const OTP_EXPIRATION_MINUTES = 2;
+    private const RATE_LIMIT_SECONDS = 120;
+
+    public function send(SendOtpRequest $request): JsonResponse
+    {
+        $mobile = $request->validated()['mobile'];
+        $rateLimiterKey = $this->rateLimiterKey($mobile);
+
+        if (RateLimiter::tooManyAttempts($rateLimiterKey, 1)) {
+            return ApiResponse::error(
+                'Please wait before requesting another OTP.',
+                Response::HTTP_TOO_MANY_REQUESTS,
+                ['retry_after' => RateLimiter::availableIn($rateLimiterKey)]
+            );
+        }
+
+        $code = str_pad((string) random_int(0, (10 ** self::OTP_LENGTH) - 1), self::OTP_LENGTH, '0', STR_PAD_LEFT);
+
+        Otp::create([
+            'mobile' => $mobile,
+            'code' => Hash::make($code),
+            'expires_at' => now()->addMinutes(self::OTP_EXPIRATION_MINUTES),
+            'meta' => [
+                'ip' => $request->ip(),
+                'user_agent' => $request->userAgent(),
+            ],
+        ]);
+
+        RateLimiter::hit($rateLimiterKey, self::RATE_LIMIT_SECONDS);
+
+        SendSmsMessage::dispatch($mobile, 'verify', ['code' => $code])->onQueue('sms');
+
+        return ApiResponse::success(
+            'OTP has been sent successfully.',
+            [
+                'expires_in' => self::OTP_EXPIRATION_MINUTES * 60,
+            ],
+            Response::HTTP_CREATED
+        );
+    }
+
+    public function verify(VerifyOtpRequest $request): JsonResponse
+    {
+        $data = $request->validated();
+        $mobile = $data['mobile'];
+
+        $otp = Otp::where('mobile', $mobile)
+            ->whereNull('used_at')
+            ->latest()
+            ->first();
+
+        if (! $otp || $otp->hasExpired() || ! Hash::check($data['otp'], $otp->code)) {
+            if ($otp) {
+                $otp->incrementAttempts();
+            }
+
+            return ApiResponse::error('Invalid or expired OTP.', Response::HTTP_UNPROCESSABLE_ENTITY);
+        }
+
+        $existingUser = User::withTrashed()->where('mobile', $mobile)->first();
+
+        $usernameProvided = array_key_exists('username', $data);
+        $username = $data['username'] ?? null;
+        if ($username) {
+            $usernameQuery = User::where('username', $username);
+            if ($existingUser) {
+                $usernameQuery->where('id', '!=', $existingUser->id);
+            } else {
+                $usernameQuery->where('mobile', '!=', $mobile);
+            }
+
+            if ($usernameQuery->exists()) {
+                return ApiResponse::error(
+                    'The chosen username is already in use.',
+                    Response::HTTP_UNPROCESSABLE_ENTITY,
+                    ['username' => ['The username has already been taken.']]
+                );
+            }
+        }
+
+        $emailProvided = array_key_exists('email', $data);
+        $email = $data['email'] ?? null;
+        if ($emailProvided && $email) {
+            $emailQuery = User::where('email', $email);
+            if ($existingUser) {
+                $emailQuery->where('id', '!=', $existingUser->id);
+            }
+
+            if ($emailQuery->exists()) {
+                return ApiResponse::error(
+                    'The provided email address is already in use.',
+                    Response::HTTP_UNPROCESSABLE_ENTITY,
+                    ['email' => ['The email has already been taken.']]
+                );
+            }
+        }
+
+        $user = DB::transaction(function () use ($data, $mobile, $otp, $username, $usernameProvided, $email, $emailProvided, $existingUser) {
+            $otp->markAsUsed();
+
+            if ($existingUser && $existingUser->trashed()) {
+                $existingUser->restore();
+            }
+
+            $user = $existingUser ?? new User();
+
+            if (! $user->exists) {
+                $user->mobile = $mobile;
+                $user->username = $username ?: $this->generateUsernameFromMobile($mobile);
+            } else {
+                if ($usernameProvided && $username !== null) {
+                    $user->username = $username;
+                } elseif (! $user->username) {
+                    $user->username = $this->generateUsernameFromMobile($mobile);
+                }
+            }
+
+            if ($emailProvided) {
+                $user->email = $email;
+            }
+
+            $user->save();
+
+            $profile = $user->profile()->firstOrCreate([]);
+
+            $profileData = collect($data)
+                ->only([
+                    'first_name',
+                    'last_name',
+                    'birth_date',
+                    'national_id',
+                    'residence_city_id',
+                    'residence_province_id',
+                ])
+                ->filter(static fn ($value) => $value !== null)
+                ->toArray();
+
+            if ($profileData !== []) {
+                $profile->fill($profileData)->save();
+            }
+
+            return $user->fresh('profile');
+        });
+
+        RateLimiter::clear($this->rateLimiterKey($mobile));
+
+        $tokenResult = $user->createToken('mobile-auth');
+        $tokenModel = $tokenResult->token;
+
+        if ($tokenModel === null) {
+            report(new RuntimeException('Unable to retrieve the issued access token instance.'));
+
+            return ApiResponse::error(
+                'Unable to generate authentication tokens. Please try again later.',
+                Response::HTTP_INTERNAL_SERVER_ERROR
+            );
+        }
+
+        if ($tokenModel->refreshToken) {
+            $tokenModel->refreshToken()->delete();
+        }
+
+        $refreshToken = Str::random(80);
+
+        $tokenModel->refreshToken()->create([
+            'id' => $refreshToken,
+            'revoked' => false,
+            'expires_at' => now()->add(Passport::refreshTokensExpireIn()),
+        ]);
+
+        $profile = $user->profile->loadMissing('user.roles', 'user.permissions');
+
+        $expiresIn = $tokenResult->expiresIn;
+
+        return ApiResponse::success(
+            'Authenticated successfully.',
+            [
+                'access_token' => $tokenResult->accessToken,
+                'refresh_token' => $refreshToken,
+                'token_type' => $tokenResult->tokenType ?? 'Bearer',
+                'expires_in' => $expiresIn !== null ? (int) $expiresIn : null,
+                'expires_at' => optional($tokenModel->expires_at)->toDateTimeString(),
+                'profile' => new ProfileResource($profile),
+            ]
+        );
+    }
+
+    private function rateLimiterKey(string $mobile): string
+    {
+        return 'otp:' . $mobile;
+    }
+
+    private function generateUsernameFromMobile(string $mobile): string
+    {
+        $suffix = substr($mobile, -4);
+
+        do {
+            $candidate = Str::lower('user_' . $suffix . random_int(100, 999));
+        } while (User::where('username', $candidate)->exists());
+
+        return $candidate;
+    }
+}

--- a/Modules/Auth/app/Http/Controllers/Api/ProfileController.php
+++ b/Modules/Auth/app/Http/Controllers/Api/ProfileController.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Modules\Auth\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Support\ApiResponse;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Modules\Auth\Http\Requests\ProfileUpdateRequest;
+use Modules\Auth\Http\Resources\ProfileResource;
+
+class ProfileController extends Controller
+{
+    public function show(Request $request): JsonResponse
+    {
+        $user = $request->user();
+        $profile = $user->profile()->firstOrCreate([]);
+
+        $profile->loadMissing('user.roles', 'user.permissions');
+
+        return ApiResponse::success(
+            'Profile retrieved successfully.',
+            [
+                'profile' => new ProfileResource($profile),
+            ]
+        );
+    }
+
+    public function update(ProfileUpdateRequest $request): JsonResponse
+    {
+        $user = $request->user();
+        $profile = $user->profile()->firstOrCreate([]);
+
+        $profile->fill($request->validated());
+        $profile->save();
+
+        $profile->loadMissing('user.roles', 'user.permissions');
+
+        return ApiResponse::success(
+            'Profile updated successfully.',
+            [
+                'profile' => new ProfileResource($profile),
+            ]
+        );
+    }
+}

--- a/Modules/Auth/app/Http/Controllers/Api/UserController.php
+++ b/Modules/Auth/app/Http/Controllers/Api/UserController.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Modules\Auth\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\User;
+use App\Support\ApiResponse;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Modules\Auth\Http\Requests\UserUpdateRequest;
+
+class UserController extends Controller
+{
+    public function show(Request $request): JsonResponse
+    {
+        /** @var User $user */
+        $user = $request->user();
+        $user->loadMissing('roles', 'permissions');
+
+        return ApiResponse::success(
+            'User retrieved successfully.',
+            [
+                'user' => $this->transformUser($user),
+            ]
+        );
+    }
+
+    public function update(UserUpdateRequest $request): JsonResponse
+    {
+        /** @var User $user */
+        $user = $request->user();
+
+        $data = $request->validated();
+
+        $user->fill($data);
+        $user->save();
+
+        $user->loadMissing('roles', 'permissions');
+
+        return ApiResponse::success(
+            'User updated successfully.',
+            [
+                'user' => $this->transformUser($user),
+            ]
+        );
+    }
+
+    private function transformUser(User $user): array
+    {
+        return [
+            'id' => $user->id,
+            'mobile' => $user->mobile,
+            'username' => $user->username,
+            'email' => $user->email,
+            'roles' => $user->getRoleNames()->values(),
+            'permissions' => $user->getPermissionNames()->values(),
+            'created_at' => $user->created_at,
+            'updated_at' => $user->updated_at,
+        ];
+    }
+}

--- a/Modules/Auth/app/Http/Requests/ProfileUpdateRequest.php
+++ b/Modules/Auth/app/Http/Requests/ProfileUpdateRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Modules\Auth\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class ProfileUpdateRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'first_name' => ['nullable', 'string', 'max:191'],
+            'last_name' => ['nullable', 'string', 'max:191'],
+            'birth_date' => ['nullable', 'date', 'before_or_equal:today'],
+            'national_id' => ['nullable', 'string', 'max:191'],
+            'residence_city_id' => ['nullable', 'integer', 'min:1'],
+            'residence_province_id' => ['nullable', 'integer', 'min:1'],
+        ];
+    }
+}

--- a/Modules/Auth/app/Http/Requests/SendOtpRequest.php
+++ b/Modules/Auth/app/Http/Requests/SendOtpRequest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Modules\Auth\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class SendOtpRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'mobile' => ['required', 'string', 'regex:/^[0-9]{10,15}$/'],
+        ];
+    }
+}

--- a/Modules/Auth/app/Http/Requests/UserUpdateRequest.php
+++ b/Modules/Auth/app/Http/Requests/UserUpdateRequest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Modules\Auth\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class UserUpdateRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        $userId = $this->user()?->getKey();
+
+        return [
+            'username' => [
+                'nullable',
+                'string',
+                'max:191',
+                Rule::unique('users', 'username')->ignore($userId),
+            ],
+            'email' => [
+                'nullable',
+                'email',
+                'max:191',
+                Rule::unique('users', 'email')->ignore($userId),
+            ],
+        ];
+    }
+}

--- a/Modules/Auth/app/Http/Requests/VerifyOtpRequest.php
+++ b/Modules/Auth/app/Http/Requests/VerifyOtpRequest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Modules\Auth\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class VerifyOtpRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'mobile' => ['required', 'string', 'regex:/^[0-9]{10,15}$/'],
+            'otp' => ['required', 'string', 'digits:6'],
+            'username' => ['nullable', 'string', 'max:191'],
+            'email' => ['nullable', 'email', 'max:191'],
+            'first_name' => ['nullable', 'string', 'max:191'],
+            'last_name' => ['nullable', 'string', 'max:191'],
+            'birth_date' => ['nullable', 'date', 'before_or_equal:today'],
+            'national_id' => ['nullable', 'string', 'max:191'],
+            'residence_city_id' => ['nullable', 'integer', 'min:1'],
+            'residence_province_id' => ['nullable', 'integer', 'min:1'],
+        ];
+    }
+}

--- a/Modules/Auth/app/Http/Resources/ProfileResource.php
+++ b/Modules/Auth/app/Http/Resources/ProfileResource.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Modules\Auth\Http\Resources;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+use Modules\Auth\Models\Profile;
+
+/**
+ * @mixin Profile
+ */
+class ProfileResource extends JsonResource
+{
+    public function toArray($request): array
+    {
+        $user = $this->whenLoaded('user');
+
+        return [
+            'id' => $this->id,
+            'first_name' => $this->first_name,
+            'last_name' => $this->last_name,
+            'full_name' => $this->full_name,
+            'birth_date' => $this->birth_date?->toDateString(),
+            'national_id' => $this->national_id,
+            'residence_city_id' => $this->residence_city_id,
+            'residence_province_id' => $this->residence_province_id,
+            'user' => $user ? [
+                'id' => $user->id,
+                'mobile' => $user->mobile,
+                'username' => $user->username,
+                'email' => $user->email,
+                'roles' => $user->getRoleNames()->values(),
+                'permissions' => $user->getPermissionNames()->values(),
+            ] : null,
+            'media' => [
+                'national_id_document' => optional($this->getFirstMedia(Profile::COLLECTION_NATIONAL_ID))?->getUrl(),
+                'profile_images' => $this->getMedia(Profile::COLLECTION_PROFILE_IMAGES)
+                    ->map(fn ($media) => [
+                        'id' => $media->uuid ?? $media->id,
+                        'name' => $media->name,
+                        'url' => $media->getUrl(),
+                    ])->values(),
+            ],
+            'created_at' => $this->created_at,
+            'updated_at' => $this->updated_at,
+        ];
+    }
+}

--- a/Modules/Auth/app/Jobs/SendSmsMessage.php
+++ b/Modules/Auth/app/Jobs/SendSmsMessage.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Modules\Auth\Jobs;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Metti\LaravelSms\Facade\SendSMS;
+
+class SendSmsMessage implements ShouldQueue
+{
+    use Dispatchable;
+    use InteractsWithQueue;
+    use Queueable;
+    use SerializesModels;
+
+    public int $tries = 5;
+
+    public int $backoff = 60;
+
+    public function __construct(
+        private readonly string $mobile,
+        private readonly string $pattern,
+        private readonly array $parameters
+    ) {
+    }
+
+    public function handle(): void
+    {
+        SendSMS::via('ippanel')
+            ->patternMessage($this->pattern, $this->parameters)
+            ->recipients([$this->mobile])
+            ->send();
+    }
+}

--- a/Modules/Auth/app/Models/Otp.php
+++ b/Modules/Auth/app/Models/Otp.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Modules\Auth\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Otp extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'mobile',
+        'code',
+        'expires_at',
+        'used_at',
+        'attempts',
+        'meta',
+    ];
+
+    protected $casts = [
+        'expires_at' => 'datetime',
+        'used_at' => 'datetime',
+        'meta' => 'array',
+    ];
+
+    public function markAsUsed(): void
+    {
+        $this->forceFill([
+            'used_at' => now(),
+        ])->save();
+    }
+
+    public function incrementAttempts(): void
+    {
+        $this->increment('attempts');
+    }
+
+    public function hasExpired(): bool
+    {
+        return $this->expires_at->isPast();
+    }
+}

--- a/Modules/Auth/app/Models/Profile.php
+++ b/Modules/Auth/app/Models/Profile.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Modules\Auth\Models;
+
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Spatie\MediaLibrary\HasMedia;
+use Spatie\MediaLibrary\InteractsWithMedia;
+
+class Profile extends Model implements HasMedia
+{
+    use HasFactory;
+    use InteractsWithMedia;
+
+    public const COLLECTION_NATIONAL_ID = 'national_id_document';
+    public const COLLECTION_PROFILE_IMAGES = 'profile_images';
+
+    protected $fillable = [
+        'user_id',
+        'first_name',
+        'last_name',
+        'birth_date',
+        'national_id',
+        'residence_city_id',
+        'residence_province_id',
+    ];
+
+    protected $casts = [
+        'birth_date' => 'date',
+        'residence_city_id' => 'integer',
+        'residence_province_id' => 'integer',
+    ];
+
+    protected $appends = ['full_name'];
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    protected static function newFactory()
+    {
+        return \Database\Factories\ProfileFactory::new();
+    }
+
+    public function getFullNameAttribute(): ?string
+    {
+        $parts = array_filter([$this->first_name, $this->last_name]);
+
+        return $parts !== [] ? implode(' ', $parts) : null;
+    }
+
+    public function registerMediaCollections(): void
+    {
+        $this
+            ->addMediaCollection(self::COLLECTION_NATIONAL_ID)
+            ->singleFile();
+
+        $this->addMediaCollection(self::COLLECTION_PROFILE_IMAGES);
+    }
+}

--- a/Modules/Auth/routes/api.php
+++ b/Modules/Auth/routes/api.php
@@ -1,8 +1,19 @@
 <?php
 
 use Illuminate\Support\Facades\Route;
-use Modules\Auth\Http\Controllers\AuthController;
+use Modules\Auth\Http\Controllers\Api\MobileAuthController;
+use Modules\Auth\Http\Controllers\Api\ProfileController;
+use Modules\Auth\Http\Controllers\Api\UserController;
 
-Route::middleware(['auth:sanctum'])->prefix('v1')->group(function () {
-    Route::apiResource('auths', AuthController::class)->names('auth');
+Route::prefix('auth')->group(function () {
+    Route::post('otp/send', [MobileAuthController::class, 'send']);
+    Route::post('otp/verify', [MobileAuthController::class, 'verify']);
+
+    Route::middleware('auth:api')->group(function () {
+        Route::get('profile', [ProfileController::class, 'show']);
+        Route::post('profile', [ProfileController::class, 'update']);
+
+        Route::get('user', [UserController::class, 'show']);
+        Route::post('user', [UserController::class, 'update']);
+    });
 });

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -2,15 +2,21 @@
 
 namespace App\Models;
 
-// use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\HasOne;
+use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
+use Laravel\Passport\HasApiTokens;
+use Modules\Auth\Models\Profile;
+use Spatie\Permission\Traits\HasRoles;
 
 class User extends Authenticatable
 {
     /** @use HasFactory<\Database\Factories\UserFactory> */
-    use HasFactory, Notifiable;
+    use HasApiTokens, HasFactory, HasRoles, Notifiable, SoftDeletes;
+
+    protected string $guard_name = 'api';
 
     /**
      * The attributes that are mass assignable.
@@ -18,9 +24,13 @@ class User extends Authenticatable
      * @var list<string>
      */
     protected $fillable = [
-        'name',
         'email',
         'password',
+        'mobile',
+        'username',
+        'two_factor_secret',
+        'two_factor_recovery_codes',
+        'two_factor_confirmed_at',
     ];
 
     /**
@@ -31,6 +41,8 @@ class User extends Authenticatable
     protected $hidden = [
         'password',
         'remember_token',
+        'two_factor_secret',
+        'two_factor_recovery_codes',
     ];
 
     /**
@@ -43,6 +55,12 @@ class User extends Authenticatable
         return [
             'email_verified_at' => 'datetime',
             'password' => 'hashed',
+            'two_factor_confirmed_at' => 'datetime',
         ];
+    }
+
+    public function profile(): HasOne
+    {
+        return $this->hasOne(Profile::class);
     }
 }

--- a/app/Support/ApiResponse.php
+++ b/app/Support/ApiResponse.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Support;
+
+use Illuminate\Http\JsonResponse;
+use Symfony\Component\HttpFoundation\Response;
+
+class ApiResponse
+{
+    public static function success(
+        string $message = '',
+        mixed $data = null,
+        int $status = Response::HTTP_OK,
+        array $meta = []
+    ): JsonResponse {
+        return response()->json([
+            'success' => true,
+            'message' => $message,
+            'data' => $data,
+            'meta' => (object) $meta,
+        ], $status);
+    }
+
+    public static function error(
+        string $message,
+        int $status = Response::HTTP_BAD_REQUEST,
+        array $errors = [],
+        mixed $data = null
+    ): JsonResponse {
+        return response()->json([
+            'success' => false,
+            'message' => $message,
+            'errors' => (object) $errors,
+            'data' => $data,
+        ], $status);
+    }
+}

--- a/database/factories/ProfileFactory.php
+++ b/database/factories/ProfileFactory.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Modules\Auth\Models\Profile;
+
+/**
+ * @extends Factory<Profile>
+ */
+class ProfileFactory extends Factory
+{
+    protected $model = Profile::class;
+
+    public function definition(): array
+    {
+        return [
+            'user_id' => User::factory(),
+            'first_name' => fake()->firstName(),
+            'last_name' => fake()->lastName(),
+            'birth_date' => fake()->date(),
+            'national_id' => fake()->unique()->numerify('##########'),
+            'residence_city_id' => fake()->numberBetween(1, 1000),
+            'residence_province_id' => fake()->numberBetween(1, 1000),
+        ];
+    }
+}

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -23,12 +23,15 @@ class UserFactory extends Factory
      */
     public function definition(): array
     {
+        $email = fake()->unique()->safeEmail();
+
         return [
-            'name' => fake()->name(),
-            'email' => fake()->unique()->safeEmail(),
+            'email' => fake()->boolean(70) ? $email : null,
             'email_verified_at' => now(),
             'password' => static::$password ??= Hash::make('password'),
             'remember_token' => Str::random(10),
+            'mobile' => fake()->unique()->numerify('09#########'),
+            'username' => fake()->unique()->userName(),
         ];
     }
 

--- a/database/migrations/2025_09_24_214023_add_mobile_and_two_factor_columns_to_users_table.php
+++ b/database/migrations/2025_09_24_214023_add_mobile_and_two_factor_columns_to_users_table.php
@@ -1,0 +1,148 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        if ($this->usingSqlite()) {
+            $this->rebuildUsersTableForSqlite();
+
+            return;
+        }
+
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('mobile', 32)->unique()->after('id');
+            $table->string('username')->nullable()->unique()->after('mobile');
+            $table->softDeletes();
+            $table->text('two_factor_secret')->nullable();
+            $table->text('two_factor_recovery_codes')->nullable();
+            $table->timestamp('two_factor_confirmed_at')->nullable();
+        });
+
+        DB::statement('ALTER TABLE users MODIFY name VARCHAR(255) NULL');
+        DB::statement('ALTER TABLE users MODIFY email VARCHAR(255) NULL');
+        DB::statement('ALTER TABLE users MODIFY password VARCHAR(255) NULL');
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        if ($this->usingSqlite()) {
+            $this->rebuildUsersTableForSqliteDown();
+
+            return;
+        }
+
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn([
+                'mobile',
+                'username',
+                'deleted_at',
+                'two_factor_secret',
+                'two_factor_recovery_codes',
+                'two_factor_confirmed_at',
+            ]);
+        });
+
+        DB::statement('ALTER TABLE users MODIFY name VARCHAR(255) NOT NULL');
+        DB::statement('ALTER TABLE users MODIFY email VARCHAR(255) NOT NULL');
+        DB::statement('ALTER TABLE users MODIFY password VARCHAR(255) NOT NULL');
+    }
+
+    private function usingSqlite(): bool
+    {
+        return Schema::getConnection()->getDriverName() === 'sqlite';
+    }
+
+    private function rebuildUsersTableForSqlite(): void
+    {
+        DB::statement('PRAGMA foreign_keys=OFF');
+
+        Schema::create('users_temp', function (Blueprint $table) {
+            $table->id();
+            $table->string('mobile', 32)->unique();
+            $table->string('username')->nullable()->unique();
+            $table->string('name')->nullable();
+            $table->string('email')->nullable()->unique();
+            $table->timestamp('email_verified_at')->nullable();
+            $table->string('password')->nullable();
+            $table->rememberToken();
+            $table->text('two_factor_secret')->nullable();
+            $table->text('two_factor_recovery_codes')->nullable();
+            $table->timestamp('two_factor_confirmed_at')->nullable();
+            $table->timestamps();
+            $table->softDeletes();
+        });
+
+        $users = DB::table('users')->get();
+
+        foreach ($users as $user) {
+            DB::table('users_temp')->insert([
+                'id' => $user->id,
+                'mobile' => 'migration-temp-' . $user->id,
+                'username' => null,
+                'name' => $user->name,
+                'email' => $user->email,
+                'email_verified_at' => $user->email_verified_at,
+                'password' => $user->password,
+                'remember_token' => $user->remember_token,
+                'two_factor_secret' => null,
+                'two_factor_recovery_codes' => null,
+                'two_factor_confirmed_at' => null,
+                'created_at' => $user->created_at,
+                'updated_at' => $user->updated_at,
+                'deleted_at' => null,
+            ]);
+        }
+
+        Schema::drop('users');
+        Schema::rename('users_temp', 'users');
+
+        DB::statement('PRAGMA foreign_keys=ON');
+    }
+
+    private function rebuildUsersTableForSqliteDown(): void
+    {
+        DB::statement('PRAGMA foreign_keys=OFF');
+
+        Schema::create('users_temp', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('email')->unique();
+            $table->timestamp('email_verified_at')->nullable();
+            $table->string('password');
+            $table->rememberToken();
+            $table->timestamps();
+        });
+
+        $users = DB::table('users')->get();
+
+        foreach ($users as $user) {
+            DB::table('users_temp')->insert([
+                'id' => $user->id,
+                'name' => $user->name ?? '',
+                'email' => $user->email ?? 'user-' . $user->id . '@example.com',
+                'email_verified_at' => $user->email_verified_at,
+                'password' => $user->password ?? '',
+                'remember_token' => $user->remember_token,
+                'created_at' => $user->created_at,
+                'updated_at' => $user->updated_at,
+            ]);
+        }
+
+        Schema::drop('users');
+        Schema::rename('users_temp', 'users');
+
+        DB::statement('PRAGMA foreign_keys=ON');
+    }
+};

--- a/database/migrations/2025_09_24_214024_create_profiles_table.php
+++ b/database/migrations/2025_09_24_214024_create_profiles_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('profiles', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->string('first_name')->nullable();
+            $table->string('last_name')->nullable();
+            $table->string('national_id')->nullable()->unique();
+            $table->unsignedBigInteger('residence_city_id')->nullable();
+            $table->unsignedBigInteger('residence_province_id')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('profiles');
+    }
+};

--- a/database/migrations/2025_09_24_214026_create_otps_table.php
+++ b/database/migrations/2025_09_24_214026_create_otps_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('otps', function (Blueprint $table) {
+            $table->id();
+            $table->string('mobile', 32)->index();
+            $table->string('code');
+            $table->timestamp('expires_at');
+            $table->timestamp('used_at')->nullable();
+            $table->unsignedInteger('attempts')->default(0);
+            $table->json('meta')->nullable();
+            $table->timestamps();
+
+            $table->index(['mobile', 'expires_at']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('otps');
+    }
+};

--- a/database/migrations/2025_09_24_214653_create_media_table.php
+++ b/database/migrations/2025_09_24_214653_create_media_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('media', function (Blueprint $table) {
+            $table->id();
+            $table->morphs('model');
+            $table->uuid()->nullable()->unique();
+            $table->string('collection_name');
+            $table->string('name');
+            $table->string('file_name');
+            $table->string('mime_type')->nullable();
+            $table->string('disk');
+            $table->string('conversions_disk')->nullable();
+            $table->unsignedBigInteger('size');
+            $table->json('manipulations');
+            $table->json('custom_properties');
+            $table->json('generated_conversions');
+            $table->json('responsive_images');
+            $table->unsignedInteger('order_column')->nullable()->index();
+            $table->nullableTimestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('media');
+    }
+};

--- a/database/migrations/2025_09_25_000001_add_birth_date_to_profiles_table.php
+++ b/database/migrations/2025_09_25_000001_add_birth_date_to_profiles_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('profiles', function (Blueprint $table) {
+            $table->date('birth_date')->nullable()->after('last_name');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('profiles', function (Blueprint $table) {
+            $table->dropColumn('birth_date');
+        });
+    }
+};

--- a/database/migrations/2025_09_25_000002_remove_name_column_from_users_table.php
+++ b/database/migrations/2025_09_25_000002_remove_name_column_from_users_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            if (Schema::hasColumn('users', 'name')) {
+                $table->dropColumn('name');
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            if (! Schema::hasColumn('users', 'name')) {
+                $table->string('name')->nullable()->after('id');
+            }
+        });
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,7 +1,3 @@
 <?php
 
-use Illuminate\Support\Facades\Route;
-
-Route::get('/', function () {
-    return view('welcome');
-});
+// API routes for authentication are defined within the Auth module.

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,7 +1,12 @@
 <?php
 
+use App\Support\ApiResponse;
 use Illuminate\Support\Facades\Route;
 use Metti\LaravelSms\Facade\SendSMS;
+
+Route::get('/', function () {
+    return ApiResponse::success('API is running.');
+});
 
 Route::get('/debug-vite', function () {
     \Artisan::call('optimize:clear');

--- a/tests/Feature/Auth/MobileAuthTest.php
+++ b/tests/Feature/Auth/MobileAuthTest.php
@@ -1,0 +1,200 @@
+<?php
+
+namespace Tests\Feature\Auth;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Queue;
+use Laravel\Passport\ClientRepository;
+use Laravel\Passport\Passport;
+use Modules\Auth\Jobs\SendSmsMessage;
+use Modules\Auth\Models\Otp;
+use Modules\Auth\Models\Profile;
+use Spatie\Permission\Models\Permission;
+use Spatie\Permission\Models\Role;
+use Tests\TestCase;
+
+class MobileAuthTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_user_can_request_otp(): void
+    {
+        Queue::fake();
+
+        $mobile = '09123456789';
+
+        $response = $this->postJson('/api/auth/otp/send', [
+            'mobile' => $mobile,
+        ]);
+
+        $response
+            ->assertCreated()
+            ->assertJsonPath('success', true)
+            ->assertJsonPath('data.expires_in', 120);
+
+        $this->assertDatabaseHas('otps', [
+            'mobile' => $mobile,
+        ]);
+
+        Queue::assertPushed(SendSmsMessage::class);
+    }
+
+    public function test_user_cannot_request_otp_twice_within_cooldown(): void
+    {
+        Queue::fake();
+
+        $mobile = '09123456789';
+
+        $this->postJson('/api/auth/otp/send', ['mobile' => $mobile])->assertCreated();
+
+        $response = $this->postJson('/api/auth/otp/send', ['mobile' => $mobile]);
+
+        $response
+            ->assertStatus(429)
+            ->assertJsonPath('success', false);
+
+        $this->assertArrayHasKey('retry_after', $response->json('errors'));
+    }
+
+    public function test_user_can_verify_otp_and_receive_profile(): void
+    {
+        $mobile = '09123456789';
+        $otpCode = '123456';
+
+        $otp = Otp::create([
+            'mobile' => $mobile,
+            'code' => Hash::make($otpCode),
+            'expires_at' => now()->addMinutes(2),
+        ]);
+
+        app(ClientRepository::class)->createPersonalAccessGrantClient('Test Personal Access Client');
+
+        $response = $this->postJson('/api/auth/otp/verify', [
+            'mobile' => $mobile,
+            'otp' => $otpCode,
+            'username' => 'john_doe',
+            'email' => 'john@example.com',
+            'first_name' => 'John',
+            'last_name' => 'Doe',
+            'birth_date' => '1990-01-01',
+            'residence_city_id' => 10,
+            'residence_province_id' => 20,
+        ]);
+
+        $response
+            ->assertOk()
+            ->assertJsonPath('success', true)
+            ->assertJsonPath('data.token_type', 'Bearer')
+            ->assertJsonPath('data.profile.first_name', 'John')
+            ->assertJsonPath('data.profile.full_name', 'John Doe')
+            ->assertJsonPath('data.profile.birth_date', '1990-01-01')
+            ->assertJsonPath('data.profile.user.mobile', $mobile)
+            ->assertJsonPath('data.profile.user.email', 'john@example.com');
+
+        $issuedTokens = $response->json('data');
+
+        $this->assertIsString($issuedTokens['access_token']);
+        $this->assertNotSame('', $issuedTokens['access_token']);
+        $this->assertIsString($issuedTokens['refresh_token']);
+        $this->assertNotSame('', $issuedTokens['refresh_token']);
+        $this->assertIsInt($issuedTokens['expires_in']);
+
+        $this->assertNotNull($otp->fresh()->used_at);
+
+        $this->assertDatabaseHas('users', [
+            'mobile' => $mobile,
+            'username' => 'john_doe',
+            'email' => 'john@example.com',
+        ]);
+
+        $profileRecord = Profile::where('user_id', User::where('mobile', $mobile)->value('id'))->first();
+        $this->assertNotNull($profileRecord);
+        $this->assertSame(10, $profileRecord->residence_city_id);
+        $this->assertSame(20, $profileRecord->residence_province_id);
+        $this->assertSame('1990-01-01', optional($profileRecord->birth_date)->toDateString());
+    }
+
+    public function test_authenticated_user_can_fetch_profile(): void
+    {
+        $user = User::factory()->create();
+        $profile = Profile::factory()->for($user)->create([
+            'first_name' => 'Jane',
+            'last_name' => 'Doe',
+            'birth_date' => '1992-02-02',
+        ]);
+
+        $role = Role::create(['name' => 'member', 'guard_name' => 'api']);
+        $permission = Permission::create(['name' => 'view-profile', 'guard_name' => 'api']);
+
+        $user->assignRole($role);
+        $user->givePermissionTo($permission);
+
+        Passport::actingAs($user);
+
+        $response = $this->getJson('/api/auth/profile');
+
+        $response
+            ->assertOk()
+            ->assertJsonPath('success', true)
+            ->assertJsonPath('data.profile.id', $profile->id)
+            ->assertJsonPath('data.profile.full_name', 'Jane Doe')
+            ->assertJsonPath('data.profile.birth_date', '1992-02-02')
+            ->assertJsonPath('data.profile.user.roles.0', 'member')
+            ->assertJsonPath('data.profile.user.permissions.0', 'view-profile');
+    }
+
+    public function test_authenticated_user_can_update_profile(): void
+    {
+        $user = User::factory()->create();
+        Passport::actingAs($user);
+
+        $response = $this->postJson('/api/auth/profile', [
+            'first_name' => 'Alice',
+            'last_name' => 'Wonderland',
+            'birth_date' => '1995-05-05',
+            'residence_city_id' => 55,
+        ]);
+
+        $response
+            ->assertOk()
+            ->assertJsonPath('success', true)
+            ->assertJsonPath('data.profile.full_name', 'Alice Wonderland')
+            ->assertJsonPath('data.profile.birth_date', '1995-05-05')
+            ->assertJsonPath('data.profile.residence_city_id', 55);
+
+        $updatedProfile = Profile::where('user_id', $user->id)->first();
+        $this->assertNotNull($updatedProfile);
+        $this->assertSame('Alice', $updatedProfile->first_name);
+        $this->assertSame('Wonderland', $updatedProfile->last_name);
+        $this->assertSame('1995-05-05', optional($updatedProfile->birth_date)->toDateString());
+    }
+
+    public function test_authenticated_user_can_update_account_details(): void
+    {
+        $user = User::factory()->create([
+            'username' => 'original_username',
+            'email' => null,
+        ]);
+
+        Passport::actingAs($user);
+
+        $response = $this->postJson('/api/auth/user', [
+            'username' => 'updated_username',
+            'email' => 'updated@example.com',
+        ]);
+
+        $response
+            ->assertOk()
+            ->assertJsonPath('success', true)
+            ->assertJsonPath('data.user.username', 'updated_username')
+            ->assertJsonPath('data.user.email', 'updated@example.com');
+
+        $this->assertDatabaseHas('users', [
+            'id' => $user->id,
+            'username' => 'updated_username',
+            'email' => 'updated@example.com',
+        ]);
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -6,5 +6,19 @@ use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
 
 abstract class TestCase extends BaseTestCase
 {
-    //
+    private static bool $passportKeysGenerated = false;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if (! self::$passportKeysGenerated) {
+            \Illuminate\Support\Facades\Artisan::call('passport:keys', [
+                '--no-interaction' => true,
+                '--force' => true,
+            ]);
+
+            self::$passportKeysGenerated = true;
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- update the OTP verification flow to mint Passport personal access tokens and persist matching refresh tokens
- return structured access, refresh, and expiry metadata alongside the authenticated profile payload
- extend the OTP feature test to ensure access and refresh tokens along with expiry data are present in the API response

## Testing
- php artisan test

------
https://chatgpt.com/codex/tasks/task_e_68d464954498832b8068149cbf672dc5