### PR TITLE
Use POST for admin settings updates

### DIFF
--- a/Modules/Settings/app/Http/Controllers/Api/AdminSettingController.php
+++ b/Modules/Settings/app/Http/Controllers/Api/AdminSettingController.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Modules\Settings\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Support\ApiResponse;
+use Illuminate\Http\JsonResponse;
+use Modules\Settings\Http\Requests\UpdateSettingsRequest;
+use Modules\Settings\Services\SettingService;
+
+class AdminSettingController extends Controller
+{
+    public function __construct(private readonly SettingService $settings)
+    {
+    }
+
+    public function index(): JsonResponse
+    {
+        $keys = $this->settings->allowedKeys();
+        $values = $this->settings->getSettings($keys);
+
+        return ApiResponse::success(
+            'Settings retrieved successfully.',
+            [
+                'settings' => $this->settings->present($keys, $values),
+            ]
+        );
+    }
+
+    public function store(UpdateSettingsRequest $request): JsonResponse
+    {
+        $this->settings->updateSettings($request->settings());
+
+        $keys = $this->settings->allowedKeys();
+        $values = $this->settings->getSettings($keys);
+
+        return ApiResponse::success(
+            'Settings updated successfully.',
+            [
+                'settings' => $this->settings->present($keys, $values),
+            ]
+        );
+    }
+}

--- a/Modules/Settings/app/Http/Controllers/Api/PublicSettingController.php
+++ b/Modules/Settings/app/Http/Controllers/Api/PublicSettingController.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Modules\Settings\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Support\ApiResponse;
+use Illuminate\Http\JsonResponse;
+use Modules\Settings\Models\Setting;
+use Modules\Settings\Services\SettingService;
+use Symfony\Component\HttpFoundation\Response;
+
+class PublicSettingController extends Controller
+{
+    public function __construct(private readonly SettingService $settings)
+    {
+    }
+
+    public function index(): JsonResponse
+    {
+        $keys = $this->settings->publicKeys();
+        $values = $this->settings->getSettings($keys);
+
+        return ApiResponse::success(
+            'Settings retrieved successfully.',
+            [
+                'settings' => $this->settings->present($keys, $values),
+            ]
+        );
+    }
+
+    public function show(string $key): JsonResponse
+    {
+        if (! in_array($key, $this->settings->publicKeys(), true)) {
+            abort(Response::HTTP_NOT_FOUND);
+        }
+
+        $setting = Setting::query()->firstWhere('key', $key);
+
+        return ApiResponse::success(
+            'Setting retrieved successfully.',
+            [
+                'setting' => [
+                    'key' => $key,
+                    'value' => $setting?->value,
+                    'description' => config('settings.keys.' . $key . '.description'),
+                    'is_public' => true,
+                ],
+            ]
+        );
+    }
+}

--- a/Modules/Settings/app/Http/Requests/UpdateSettingsRequest.php
+++ b/Modules/Settings/app/Http/Requests/UpdateSettingsRequest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Modules\Settings\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateSettingsRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return $this->user('api') !== null;
+    }
+
+    public function rules(): array
+    {
+        $rules = [];
+
+        foreach (config('settings.keys', []) as $key => $meta) {
+            $rules[$key] = ['nullable', 'string'];
+        }
+
+        return $rules;
+    }
+
+    public function settings(): array
+    {
+        return $this->validated();
+    }
+}

--- a/Modules/Settings/app/Models/Setting.php
+++ b/Modules/Settings/app/Models/Setting.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Modules\Settings\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * @property string $key
+ * @property string|null $value
+ */
+class Setting extends Model
+{
+    use HasFactory;
+
+    /**
+     * @var list<string>
+     */
+    protected $fillable = [
+        'key',
+        'value',
+    ];
+
+    /**
+     * @var array<string, string>
+     */
+    protected $casts = [
+        'value' => 'string',
+    ];
+
+    /**
+     * Scope a query to only include the provided keys.
+     */
+    public function scopeForKeys($query, array $keys)
+    {
+        return $query->whereIn('key', $keys);
+    }
+}

--- a/Modules/Settings/app/Providers/SettingsServiceProvider.php
+++ b/Modules/Settings/app/Providers/SettingsServiceProvider.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Modules\Settings\Providers;
+
+use Illuminate\Support\ServiceProvider;
+use Modules\Settings\Services\SettingService;
+
+class SettingsServiceProvider extends ServiceProvider
+{
+    public function register(): void
+    {
+        $this->app->singleton(SettingService::class, static fn () => new SettingService());
+
+        $this->mergeConfigFrom($this->configPath(), 'settings');
+    }
+
+    public function boot(): void
+    {
+        $this->publishes([
+            $this->configPath() => config_path('settings.php'),
+        ], 'settings-config');
+
+        $this->loadRoutesFrom($this->routesPath());
+        $this->loadMigrationsFrom($this->migrationsPath());
+    }
+
+    private function configPath(): string
+    {
+        return __DIR__ . '/../../config/config.php';
+    }
+
+    private function routesPath(): string
+    {
+        return __DIR__ . '/../../routes/api.php';
+    }
+
+    private function migrationsPath(): string
+    {
+        return __DIR__ . '/../../database/migrations';
+    }
+}

--- a/Modules/Settings/app/Services/SettingService.php
+++ b/Modules/Settings/app/Services/SettingService.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Modules\Settings\Services;
+
+use Illuminate\Support\Arr;
+use Illuminate\Support\Collection;
+use Modules\Settings\Models\Setting;
+
+class SettingService
+{
+    public function allowedKeys(): array
+    {
+        return array_keys(config('settings.keys', []));
+    }
+
+    public function publicKeys(): array
+    {
+        return array_keys(array_filter(config('settings.keys', []), static function (array $meta): bool {
+            return $meta['public'] ?? false;
+        }));
+    }
+
+    public function getSettings(?array $keys = null): Collection
+    {
+        $query = Setting::query();
+
+        if (! empty($keys)) {
+            $query->forKeys($keys);
+        }
+
+        $settings = $query->get()->pluck('value', 'key');
+
+        if ($keys !== null) {
+            $settings = collect($keys)->mapWithKeys(static function (string $key) use ($settings) {
+                return [$key => $settings->get($key)];
+            });
+        }
+
+        return $settings;
+    }
+
+    public function updateSettings(array $values): Collection
+    {
+        $values = Arr::only($values, $this->allowedKeys());
+
+        foreach ($values as $key => $value) {
+            Setting::query()->updateOrCreate(
+                ['key' => $key],
+                ['value' => $value]
+            );
+        }
+
+        return $this->getSettings(array_keys($values));
+    }
+
+    public function present(array $keys, Collection $values): array
+    {
+        return collect($keys)->map(function (string $key) use ($values) {
+            $meta = config('settings.keys.' . $key, []);
+
+            return [
+                'key' => $key,
+                'value' => $values->get($key),
+                'description' => $meta['description'] ?? null,
+                'is_public' => (bool) ($meta['public'] ?? false),
+            ];
+        })->values()->toArray();
+    }
+}

--- a/Modules/Settings/composer.json
+++ b/Modules/Settings/composer.json
@@ -1,0 +1,29 @@
+{
+    "name": "nwidart/settings",
+    "description": "",
+    "authors": [
+        {
+            "name": "Nicolas Widart",
+            "email": "n.widart@gmail.com"
+        }
+    ],
+    "extra": {
+        "laravel": {
+            "providers": [],
+            "aliases": {
+            }
+        }
+    },
+    "autoload": {
+        "psr-4": {
+            "Modules\\Settings\\": "app/",
+            "Modules\\Settings\\Database\\Factories\\": "database/factories/",
+            "Modules\\Settings\\Database\\Seeders\\": "database/seeders/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Modules\\Settings\\Tests\\": "tests/"
+        }
+    }
+}

--- a/Modules/Settings/config/config.php
+++ b/Modules/Settings/config/config.php
@@ -1,0 +1,16 @@
+<?php
+
+return [
+    'name' => 'Settings',
+
+    'keys' => [
+        'privacy_policy' => [
+            'public' => true,
+            'description' => 'Privacy policy content presented to users.',
+        ],
+        'about_us' => [
+            'public' => true,
+            'description' => 'About us description shown across the application.',
+        ],
+    ],
+];

--- a/Modules/Settings/database/migrations/2025_09_28_232133_create_settings_table.php
+++ b/Modules/Settings/database/migrations/2025_09_28_232133_create_settings_table.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('settings', function (Blueprint $table) {
+            $table->id();
+            $table->string('key')->unique();
+            $table->longText('value')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('settings');
+    }
+};

--- a/Modules/Settings/module.json
+++ b/Modules/Settings/module.json
@@ -1,0 +1,11 @@
+{
+    "name": "Settings",
+    "alias": "settings",
+    "description": "",
+    "keywords": [],
+    "priority": 0,
+    "providers": [
+        "Modules\\Settings\\Providers\\SettingsServiceProvider"
+    ],
+    "files": []
+}

--- a/Modules/Settings/routes/api.php
+++ b/Modules/Settings/routes/api.php
@@ -1,0 +1,17 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+use Modules\Settings\Http\Controllers\Api\AdminSettingController;
+use Modules\Settings\Http\Controllers\Api\PublicSettingController;
+
+Route::middleware('api')->prefix('api')->group(function () {
+    Route::prefix('settings')->group(function () {
+        Route::get('/', [PublicSettingController::class, 'index']);
+        Route::get('{key}', [PublicSettingController::class, 'show']);
+    });
+
+    Route::middleware('auth:api')->prefix('admin/settings')->group(function () {
+        Route::get('/', [AdminSettingController::class, 'index']);
+        Route::post('/', [AdminSettingController::class, 'store']);
+    });
+});

--- a/modules_statuses.json
+++ b/modules_statuses.json
@@ -1,4 +1,5 @@
 {
     "Auth": true,
-    "Notification": false
+    "Notification": false,
+    "Settings": true
 }

--- a/tests/Feature/Settings/SettingsApiTest.php
+++ b/tests/Feature/Settings/SettingsApiTest.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace Tests\Feature\Settings;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Passport\Passport;
+use Modules\Settings\Models\Setting;
+use Tests\TestCase;
+
+class SettingsApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_public_settings_index_returns_all_public_entries(): void
+    {
+        Setting::query()->create([
+            'key' => 'privacy_policy',
+            'value' => 'Our privacy commitment.',
+        ]);
+
+        $response = $this->getJson('/api/settings');
+
+        $response
+            ->assertOk()
+            ->assertJsonPath('success', true)
+            ->assertJsonPath('data.settings.0.key', 'privacy_policy')
+            ->assertJsonPath('data.settings.0.value', 'Our privacy commitment.')
+            ->assertJsonPath('data.settings.0.is_public', true)
+            ->assertJsonPath('data.settings.1.key', 'about_us')
+            ->assertJsonPath('data.settings.1.value', null)
+            ->assertJsonPath('data.settings.1.is_public', true);
+    }
+
+    public function test_public_settings_show_returns_single_entry(): void
+    {
+        Setting::query()->create([
+            'key' => 'about_us',
+            'value' => 'We build great apps.',
+        ]);
+
+        $response = $this->getJson('/api/settings/about_us');
+
+        $response
+            ->assertOk()
+            ->assertJsonPath('success', true)
+            ->assertJsonPath('data.setting.key', 'about_us')
+            ->assertJsonPath('data.setting.value', 'We build great apps.')
+            ->assertJsonPath('data.setting.is_public', true);
+    }
+
+    public function test_admin_can_view_and_update_settings_via_post(): void
+    {
+        Setting::query()->create([
+            'key' => 'about_us',
+            'value' => 'First version.',
+        ]);
+
+        $user = User::factory()->create();
+        Passport::actingAs($user);
+
+        $this->getJson('/api/admin/settings')
+            ->assertOk()
+            ->assertJsonPath('data.settings.0.key', 'privacy_policy')
+            ->assertJsonPath('data.settings.1.value', 'First version.');
+
+        $payload = [
+            'privacy_policy' => 'Updated privacy details.',
+            'about_us' => 'Second version.',
+        ];
+
+        $response = $this->postJson('/api/admin/settings', $payload);
+
+        $response
+            ->assertOk()
+            ->assertJsonPath('success', true)
+            ->assertJsonPath('data.settings.0.value', 'Updated privacy details.')
+            ->assertJsonPath('data.settings.1.value', 'Second version.');
+
+        $this->assertDatabaseHas('settings', [
+            'key' => 'privacy_policy',
+            'value' => 'Updated privacy details.',
+        ]);
+
+        $this->assertDatabaseHas('settings', [
+            'key' => 'about_us',
+            'value' => 'Second version.',
+        ]);
+    }
+
+    public function test_update_requires_authentication(): void
+    {
+        $this->postJson('/api/admin/settings', [
+            'privacy_policy' => 'Should not persist.',
+        ])->assertUnauthorized();
+    }
+}


### PR DESCRIPTION
## Summary
- add a Settings module with database table, config, and service abstraction for static content
- expose public and admin APIs to read and update privacy policy and about us text
- cover the new endpoints with feature tests to ensure authentication and responses
- align the admin settings update endpoint with a POST route and register module autoloading for discovery

## Testing
- php artisan test

------
https://chatgpt.com/codex/tasks/task_e_68d9c2670394832b86ad4d672e5d7b5b