### PR TITLE
Add REST geography APIs for countries, provinces, and cities

### DIFF
--- a/Modules/Auth/app/Http/Requests/ProfileUpdateRequest.php
+++ b/Modules/Auth/app/Http/Requests/ProfileUpdateRequest.php
@@ -20,6 +20,7 @@ class ProfileUpdateRequest extends FormRequest
             'national_id' => ['nullable', 'string', 'max:191'],
             'residence_city_id' => ['nullable', 'integer', 'min:1'],
             'residence_province_id' => ['nullable', 'integer', 'min:1'],
+            'profile_image' => ['nullable', 'image', 'max:5120'],
         ];
     }
 }

--- a/app/Http/Controllers/Api/CityController.php
+++ b/app/Http/Controllers/Api/CityController.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Geography\CityIndexRequest;
+use App\Http\Resources\CityResource;
+use App\Models\City;
+use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
+
+class CityController extends Controller
+{
+    public function index(CityIndexRequest $request): AnonymousResourceCollection
+    {
+        $filters = $request->validated();
+        $perPage = $filters['per_page'] ?? 50;
+
+        $cities = City::query()
+            ->with('provinceRelation.countryRelation')
+            ->when(isset($filters['id']), fn ($query) => $query->whereKey($filters['id']))
+            ->when(isset($filters['name']), function ($query) use ($filters) {
+                $name = $filters['name'];
+                $query->where(function ($inner) use ($name) {
+                    $inner
+                        ->where('name', 'like', '%' . $name . '%')
+                        ->orWhere('name_en', 'like', '%' . $name . '%');
+                });
+            })
+            ->when(isset($filters['name_en']), fn ($query) => $query->where('name_en', 'like', '%' . $filters['name_en'] . '%'))
+            ->when(isset($filters['province_id']), fn ($query) => $query->where('province', $filters['province_id']))
+            ->when(isset($filters['country_id']), function ($query) use ($filters) {
+                $query->whereHas('provinceRelation', fn ($provinceQuery) => $provinceQuery->where('country', $filters['country_id']));
+            })
+            ->when(isset($filters['latitude']), fn ($query) => $query->where('latitude', $filters['latitude']))
+            ->when(isset($filters['longitude']), fn ($query) => $query->where('longitude', $filters['longitude']))
+            ->orderBy('name_en')
+            ->paginate($perPage)
+            ->withQueryString();
+
+        return CityResource::collection($cities);
+    }
+
+    public function show(City $city): CityResource
+    {
+        $city->load('provinceRelation.countryRelation.capitalCity');
+
+        return new CityResource($city);
+    }
+}

--- a/app/Http/Controllers/Api/CountryController.php
+++ b/app/Http/Controllers/Api/CountryController.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Geography\CountryIndexRequest;
+use App\Http\Resources\CountryResource;
+use App\Models\Country;
+use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
+
+class CountryController extends Controller
+{
+    public function index(CountryIndexRequest $request): AnonymousResourceCollection
+    {
+        $filters = $request->validated();
+        $perPage = $filters['per_page'] ?? 50;
+
+        $countries = Country::query()
+            ->with('capitalCity')
+            ->when(isset($filters['id']), fn ($query) => $query->whereKey($filters['id']))
+            ->when(isset($filters['name']), function ($query) use ($filters) {
+                $name = $filters['name'];
+                $query->where(function ($inner) use ($name) {
+                    $inner
+                        ->where('name', 'like', '%' . $name . '%')
+                        ->orWhere('name_en', 'like', '%' . $name . '%');
+                });
+            })
+            ->when(isset($filters['name_en']), fn ($query) => $query->where('name_en', 'like', '%' . $filters['name_en'] . '%'))
+            ->when(isset($filters['capital_city']), fn ($query) => $query->where('capital_city', $filters['capital_city']))
+            ->orderBy('name_en')
+            ->paginate($perPage)
+            ->withQueryString();
+
+        return CountryResource::collection($countries);
+    }
+
+    public function show(Country $country): CountryResource
+    {
+        $country->load([
+            'capitalCity.provinceRelation',
+            'provinces' => fn ($query) => $query->orderBy('name_en'),
+        ]);
+
+        return new CountryResource($country);
+    }
+}

--- a/app/Http/Controllers/Api/ProvinceController.php
+++ b/app/Http/Controllers/Api/ProvinceController.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Geography\ProvinceCitiesRequest;
+use App\Http\Requests\Geography\ProvinceIndexRequest;
+use App\Http\Resources\CityResource;
+use App\Http\Resources\ProvinceResource;
+use App\Models\Province;
+use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
+
+class ProvinceController extends Controller
+{
+    public function index(ProvinceIndexRequest $request): AnonymousResourceCollection
+    {
+        $filters = $request->validated();
+        $perPage = $filters['per_page'] ?? 50;
+
+        $provinces = Province::query()
+            ->with('countryRelation')
+            ->when(isset($filters['id']), fn ($query) => $query->whereKey($filters['id']))
+            ->when(isset($filters['name']), fn ($query) => $query->where('name', 'like', '%' . $filters['name'] . '%'))
+            ->when(isset($filters['name_en']), fn ($query) => $query->where('name_en', 'like', '%' . $filters['name_en'] . '%'))
+            ->when(isset($filters['country_id']), fn ($query) => $query->where('country', $filters['country_id']))
+            ->orderBy('name_en')
+            ->paginate($perPage)
+            ->withQueryString();
+
+        return ProvinceResource::collection($provinces);
+    }
+
+    public function show(Province $province): ProvinceResource
+    {
+        $province->load([
+            'countryRelation.capitalCity',
+            'cities' => fn ($query) => $query->orderBy('name_en'),
+        ]);
+
+        return new ProvinceResource($province);
+    }
+
+    public function cities(ProvinceCitiesRequest $request, Province $province): AnonymousResourceCollection
+    {
+        $perPage = $request->validated()['per_page'] ?? 50;
+
+        $cities = $province
+            ->cities()
+            ->with('provinceRelation.countryRelation')
+            ->orderBy('name_en')
+            ->paginate($perPage)
+            ->withQueryString();
+
+        return CityResource::collection($cities);
+    }
+}

--- a/app/Http/Requests/Geography/CityIndexRequest.php
+++ b/app/Http/Requests/Geography/CityIndexRequest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Http\Requests\Geography;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class CityIndexRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'id' => ['nullable', 'integer', 'min:1'],
+            'name' => ['nullable', 'string'],
+            'name_en' => ['nullable', 'string'],
+            'province_id' => ['nullable', 'integer', 'min:1'],
+            'country_id' => ['nullable', 'integer', 'min:1'],
+            'latitude' => ['nullable', 'numeric'],
+            'longitude' => ['nullable', 'numeric'],
+            'per_page' => ['nullable', 'integer', 'min:1', 'max:100'],
+        ];
+    }
+}

--- a/app/Http/Requests/Geography/CountryIndexRequest.php
+++ b/app/Http/Requests/Geography/CountryIndexRequest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Requests\Geography;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class CountryIndexRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'id' => ['nullable', 'integer', 'min:1'],
+            'name' => ['nullable', 'string'],
+            'name_en' => ['nullable', 'string'],
+            'capital_city' => ['nullable', 'integer', 'min:1'],
+            'per_page' => ['nullable', 'integer', 'min:1', 'max:100'],
+        ];
+    }
+}

--- a/app/Http/Requests/Geography/ProvinceCitiesRequest.php
+++ b/app/Http/Requests/Geography/ProvinceCitiesRequest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Http\Requests\Geography;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class ProvinceCitiesRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'per_page' => ['nullable', 'integer', 'min:1', 'max:100'],
+        ];
+    }
+}

--- a/app/Http/Requests/Geography/ProvinceIndexRequest.php
+++ b/app/Http/Requests/Geography/ProvinceIndexRequest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Requests\Geography;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class ProvinceIndexRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'id' => ['nullable', 'integer', 'min:1'],
+            'name' => ['nullable', 'string'],
+            'name_en' => ['nullable', 'string'],
+            'country_id' => ['nullable', 'integer', 'min:1'],
+            'per_page' => ['nullable', 'integer', 'min:1', 'max:100'],
+        ];
+    }
+}

--- a/app/Http/Resources/CityResource.php
+++ b/app/Http/Resources/CityResource.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/** @mixin \App\Models\City */
+class CityResource extends JsonResource
+{
+    public function toArray($request): array
+    {
+        return [
+            'id' => $this->id,
+            'province_id' => $this->province,
+            'name' => $this->name,
+            'name_en' => $this->name_en,
+            'latitude' => $this->latitude !== null ? (float) $this->latitude : null,
+            'longitude' => $this->longitude !== null ? (float) $this->longitude : null,
+            'province' => ProvinceResource::make($this->whenLoaded('provinceRelation')),
+        ];
+    }
+}

--- a/app/Http/Resources/CountryResource.php
+++ b/app/Http/Resources/CountryResource.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/** @mixin \App\Models\Country */
+class CountryResource extends JsonResource
+{
+    public function toArray($request): array
+    {
+        return [
+            'id' => $this->id,
+            'name' => $this->name,
+            'name_en' => $this->name_en,
+            'capital_city_id' => $this->capital_city,
+            'capital_city' => CityResource::make($this->whenLoaded('capitalCity')),
+            'provinces' => ProvinceResource::collection($this->whenLoaded('provinces')),
+        ];
+    }
+}

--- a/app/Http/Resources/ProvinceResource.php
+++ b/app/Http/Resources/ProvinceResource.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/** @mixin \App\Models\Province */
+class ProvinceResource extends JsonResource
+{
+    public function toArray($request): array
+    {
+        return [
+            'id' => $this->id,
+            'country_id' => $this->country,
+            'name' => $this->name,
+            'name_en' => $this->name_en,
+            'country' => CountryResource::make($this->whenLoaded('countryRelation')),
+            'cities' => CityResource::collection($this->whenLoaded('cities')),
+        ];
+    }
+}

--- a/app/Models/City.php
+++ b/app/Models/City.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class City extends Model
+{
+    use HasFactory;
+
+    public $timestamps = false;
+
+    protected $fillable = [
+        'province',
+        'name',
+        'name_en',
+        'latitude',
+        'longitude',
+    ];
+
+    protected $casts = [
+        'province' => 'int',
+        'latitude' => 'float',
+        'longitude' => 'float',
+    ];
+
+    public function provinceRelation(): BelongsTo
+    {
+        return $this->belongsTo(Province::class, 'province');
+    }
+}

--- a/app/Models/Country.php
+++ b/app/Models/Country.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\HasManyThrough;
+
+class Country extends Model
+{
+    use HasFactory;
+
+    public $timestamps = false;
+
+    protected $fillable = [
+        'capital_city',
+        'name',
+        'name_en',
+    ];
+
+    protected $casts = [
+        'capital_city' => 'int',
+    ];
+
+    public function provinces(): HasMany
+    {
+        return $this->hasMany(Province::class, 'country');
+    }
+
+    public function cities(): HasManyThrough
+    {
+        return $this->hasManyThrough(City::class, Province::class, 'country', 'province');
+    }
+
+    public function capitalCity(): BelongsTo
+    {
+        return $this->belongsTo(City::class, 'capital_city');
+    }
+}

--- a/app/Models/Province.php
+++ b/app/Models/Province.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class Province extends Model
+{
+    use HasFactory;
+
+    public $timestamps = false;
+
+    protected $fillable = [
+        'country',
+        'name',
+        'name_en',
+    ];
+
+    protected $casts = [
+        'country' => 'int',
+    ];
+
+    public function countryRelation(): BelongsTo
+    {
+        return $this->belongsTo(Country::class, 'country');
+    }
+
+    public function cities(): HasMany
+    {
+        return $this->hasMany(City::class, 'province');
+    }
+}

--- a/database/migrations/2025_09_25_120100_create_countries_table.php
+++ b/database/migrations/2025_09_25_120100_create_countries_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('countries', function (Blueprint $table) {
+            $table->smallIncrements('id');
+            $table->unsignedSmallInteger('capital_city')->nullable();
+            $table->string('name', 255);
+            $table->string('name_en', 255);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('countries');
+    }
+};

--- a/database/migrations/2025_09_25_120101_create_provinces_table.php
+++ b/database/migrations/2025_09_25_120101_create_provinces_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('provinces', function (Blueprint $table) {
+            $table->smallIncrements('id');
+            $table->unsignedSmallInteger('country');
+            $table->string('name', 255);
+            $table->string('name_en', 255);
+
+            $table
+                ->foreign('country')
+                ->references('id')
+                ->on('countries')
+                ->cascadeOnUpdate()
+                ->restrictOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('provinces');
+    }
+};

--- a/database/migrations/2025_09_25_120102_create_cities_table.php
+++ b/database/migrations/2025_09_25_120102_create_cities_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('cities', function (Blueprint $table) {
+            $table->smallIncrements('id');
+            $table->unsignedSmallInteger('province');
+            $table->string('name', 255);
+            $table->string('name_en', 255);
+            $table->decimal('latitude', 10, 8);
+            $table->decimal('longitude', 11, 8);
+
+            $table
+                ->foreign('province')
+                ->references('id')
+                ->on('provinces')
+                ->cascadeOnUpdate()
+                ->restrictOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('cities');
+    }
+};

--- a/database/migrations/2025_09_25_120103_add_capital_city_foreign_key_to_countries_table.php
+++ b/database/migrations/2025_09_25_120103_add_capital_city_foreign_key_to_countries_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('countries', function (Blueprint $table) {
+            $table
+                ->foreign('capital_city')
+                ->references('id')
+                ->on('cities')
+                ->cascadeOnUpdate()
+                ->restrictOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('countries', function (Blueprint $table) {
+            $table->dropForeign(['capital_city']);
+        });
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,5 +1,8 @@
 <?php
 
+use App\Http\Controllers\Api\CityController;
+use App\Http\Controllers\Api\CountryController;
+use App\Http\Controllers\Api\ProvinceController;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Route;
 
@@ -70,6 +73,18 @@ Route::any('/deploy/unpacking', function () {
     }
 
     return response()->json(['ok' => true]);
+});
+
+Route::prefix('geography')->group(function () {
+    Route::get('countries', [CountryController::class, 'index']);
+    Route::get('countries/{country}', [CountryController::class, 'show']);
+
+    Route::get('provinces', [ProvinceController::class, 'index']);
+    Route::get('provinces/{province}', [ProvinceController::class, 'show']);
+    Route::get('provinces/{province}/cities', [ProvinceController::class, 'cities']);
+
+    Route::get('cities', [CityController::class, 'index']);
+    Route::get('cities/{city}', [CityController::class, 'show']);
 });
 
 

--- a/tests/Feature/Geography/GeographyApiTest.php
+++ b/tests/Feature/Geography/GeographyApiTest.php
@@ -1,0 +1,186 @@
+<?php
+
+namespace Tests\Feature\Geography;
+
+use App\Models\City;
+use App\Models\Country;
+use App\Models\Province;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class GeographyApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_can_list_countries_with_filters(): void
+    {
+        $data = $this->seedGeography();
+
+        $response = $this->getJson('/api/geography/countries');
+        $response
+            ->assertOk()
+            ->assertJsonPath('meta.total', 2);
+
+        $filtered = $this->getJson('/api/geography/countries?name=Iran');
+        $filtered
+            ->assertOk()
+            ->assertJsonCount(1, 'data')
+            ->assertJsonPath('data.0.id', $data['iran']->id);
+    }
+
+    public function test_can_show_country_with_related_data(): void
+    {
+        $data = $this->seedGeography();
+
+        $response = $this->getJson('/api/geography/countries/' . $data['iran']->id);
+        $response
+            ->assertOk()
+            ->assertJsonPath('data.id', $data['iran']->id)
+            ->assertJsonCount(2, 'data.provinces')
+            ->assertJsonPath('data.capital_city.id', $data['tehranCity']->id);
+    }
+
+    public function test_can_list_provinces_with_filters(): void
+    {
+        $data = $this->seedGeography();
+
+        $response = $this->getJson('/api/geography/provinces?country_id=' . $data['iran']->id);
+        $response
+            ->assertOk()
+            ->assertJsonCount(2, 'data')
+            ->assertJsonPath('meta.total', 2)
+            ->assertJsonMissing(['country_id' => $data['iraq']->id]);
+    }
+
+    public function test_can_show_province_with_related_data(): void
+    {
+        $data = $this->seedGeography();
+
+        $response = $this->getJson('/api/geography/provinces/' . $data['tehranProvince']->id);
+        $response
+            ->assertOk()
+            ->assertJsonPath('data.country.id', $data['iran']->id)
+            ->assertJsonCount(2, 'data.cities');
+    }
+
+    public function test_can_list_cities_with_filters(): void
+    {
+        $data = $this->seedGeography();
+
+        $byName = $this->getJson('/api/geography/cities?name=Teh');
+        $byName
+            ->assertOk()
+            ->assertJsonCount(1, 'data')
+            ->assertJsonPath('meta.total', 1)
+            ->assertJsonPath('data.0.name_en', 'Tehran');
+
+        $byCoordinates = $this->getJson('/api/geography/cities?latitude=35.6892&longitude=51.389');
+        $byCoordinates
+            ->assertOk()
+            ->assertJsonCount(1, 'data')
+            ->assertJsonPath('meta.total', 1)
+            ->assertJsonPath('data.0.id', $data['tehranCity']->id);
+    }
+
+    public function test_can_show_city_with_relationships(): void
+    {
+        $data = $this->seedGeography();
+
+        $response = $this->getJson('/api/geography/cities/' . $data['tehranCity']->id);
+        $response
+            ->assertOk()
+            ->assertJsonPath('data.province.id', $data['tehranProvince']->id)
+            ->assertJsonPath('data.province.country.id', $data['iran']->id);
+    }
+
+    public function test_can_list_cities_for_province(): void
+    {
+        $data = $this->seedGeography();
+
+        $response = $this->getJson('/api/geography/provinces/' . $data['tehranProvince']->id . '/cities');
+        $response
+            ->assertOk()
+            ->assertJsonCount(2, 'data')
+            ->assertJsonPath('meta.total', 2);
+    }
+
+    private function seedGeography(): array
+    {
+        $iran = Country::create([
+            'capital_city' => null,
+            'name' => 'ایران',
+            'name_en' => 'Iran',
+        ]);
+
+        $iraq = Country::create([
+            'capital_city' => null,
+            'name' => 'عراق',
+            'name_en' => 'Iraq',
+        ]);
+
+        $tehranProvince = Province::create([
+            'country' => $iran->id,
+            'name' => 'تهران',
+            'name_en' => 'Tehran',
+        ]);
+
+        $isfahanProvince = Province::create([
+            'country' => $iran->id,
+            'name' => 'اصفهان',
+            'name_en' => 'Isfahan',
+        ]);
+
+        $baghdadProvince = Province::create([
+            'country' => $iraq->id,
+            'name' => 'بغداد',
+            'name_en' => 'Baghdad',
+        ]);
+
+        $tehranCity = City::create([
+            'province' => $tehranProvince->id,
+            'name' => 'تهران',
+            'name_en' => 'Tehran',
+            'latitude' => 35.68920000,
+            'longitude' => 51.38900000,
+        ]);
+
+        $karajCity = City::create([
+            'province' => $tehranProvince->id,
+            'name' => 'کرج',
+            'name_en' => 'Karaj',
+            'latitude' => 35.83270000,
+            'longitude' => 50.99150000,
+        ]);
+
+        $isfahanCity = City::create([
+            'province' => $isfahanProvince->id,
+            'name' => 'اصفهان',
+            'name_en' => 'Isfahan',
+            'latitude' => 32.65250000,
+            'longitude' => 51.67460000,
+        ]);
+
+        $baghdadCity = City::create([
+            'province' => $baghdadProvince->id,
+            'name' => 'بغداد',
+            'name_en' => 'Baghdad',
+            'latitude' => 33.31520000,
+            'longitude' => 44.36610000,
+        ]);
+
+        $iran->update(['capital_city' => $tehranCity->id]);
+        $iraq->update(['capital_city' => $baghdadCity->id]);
+
+        return compact(
+            'iran',
+            'iraq',
+            'tehranProvince',
+            'isfahanProvince',
+            'baghdadProvince',
+            'tehranCity',
+            'karajCity',
+            'isfahanCity',
+            'baghdadCity'
+        );
+    }
+}

--- a/tests/Feature/Geography/GeographyModelsTest.php
+++ b/tests/Feature/Geography/GeographyModelsTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Tests\Feature\Geography;
+
+use App\Models\City;
+use App\Models\Country;
+use App\Models\Province;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Tests\TestCase;
+
+class GeographyModelsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_geography_tables_have_expected_columns(): void
+    {
+        $this->assertTrue(Schema::hasColumns('countries', ['id', 'capital_city', 'name', 'name_en']));
+        $this->assertTrue(Schema::hasColumns('provinces', ['id', 'country', 'name', 'name_en']));
+        $this->assertTrue(Schema::hasColumns('cities', ['id', 'province', 'name', 'name_en', 'latitude', 'longitude']));
+    }
+
+    public function test_country_province_city_relationships(): void
+    {
+        Schema::disableForeignKeyConstraints();
+        DB::statement('PRAGMA foreign_keys = OFF');
+
+        try {
+            $country = Country::create([
+                'capital_city' => null,
+                'name' => 'ایران',
+                'name_en' => 'Iran',
+            ]);
+
+            $province = Province::create([
+                'country' => $country->id,
+                'name' => 'تهران',
+                'name_en' => 'Tehran',
+            ]);
+
+            $city = City::create([
+                'province' => $province->id,
+                'name' => 'تهران',
+                'name_en' => 'Tehran',
+                'latitude' => 35.6892,
+                'longitude' => 51.3890,
+            ]);
+
+            $country->capital_city = $city->id;
+            $country->save();
+        } finally {
+            DB::statement('PRAGMA foreign_keys = ON');
+            Schema::enableForeignKeyConstraints();
+        }
+
+        $country->refresh();
+        $province->refresh();
+        $city->refresh();
+
+        $this->assertTrue($country->provinces->contains($province));
+        $this->assertTrue($province->cities->contains($city));
+        $this->assertTrue($country->cities->contains($city));
+        $this->assertTrue($province->countryRelation->is($country));
+
+        $this->assertTrue($country->capitalCity->is($city));
+        $this->assertSame(35.6892, $city->latitude);
+        $this->assertSame(51.3890, $city->longitude);
+    }
+}


### PR DESCRIPTION
## Summary
- expose geography endpoints to list and filter countries, provinces, and cities, including province city lookups
- add request validation and JSON resources to shape consistent API responses
- cover the geography endpoints with feature tests alongside the existing model coverage

## Testing
- php artisan test

------
https://chatgpt.com/codex/tasks/task_e_68d9bbfd4080832b8647d76480323959