### PR TITLE
Add geolocation APIs for cities and provinces

### DIFF
--- a/app/Http/Controllers/Api/GeolocationController.php
+++ b/app/Http/Controllers/Api/GeolocationController.php
@@ -1,0 +1,179 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Geography\LocationLookupRequest;
+use App\Http\Requests\Geography\NearbyCitiesRequest;
+use App\Http\Requests\Geography\ResolveCityRequest;
+use App\Http\Resources\CityResource;
+use App\Http\Resources\ProvinceResource;
+use App\Models\City;
+use App\Models\Province;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
+use Illuminate\Support\Collection;
+
+class GeolocationController extends Controller
+{
+    private const DEFAULT_RADIUS_KM = 50.0;
+    private const DEFAULT_LIMIT = 10;
+    private const DEGREE_TO_RADIAN = 0.017453292519943295;
+
+    public function lookup(LocationLookupRequest $request): JsonResponse
+    {
+        $data = $request->validated();
+        $latitude = (float) $data['latitude'];
+        $longitude = (float) $data['longitude'];
+        $radius = array_key_exists('radius_km', $data) ? (float) $data['radius_km'] : self::DEFAULT_RADIUS_KM;
+        $cityLimit = (int) ($data['city_limit'] ?? self::DEFAULT_LIMIT);
+        $provinceLimit = (int) ($data['province_limit'] ?? self::DEFAULT_LIMIT);
+
+        $cities = $this->filterByRadius(
+            $this
+                ->buildCityDistanceQuery($latitude, $longitude, $radius)
+                ->orderBy('distance_km')
+                ->limit($cityLimit)
+                ->with('provinceRelation.countryRelation')
+                ->get(),
+            $radius
+        );
+
+        $provinces = $this->filterByRadius(
+            $this
+                ->buildProvinceDistanceQuery($latitude, $longitude, $radius)
+                ->orderBy('distance_km')
+                ->limit($provinceLimit)
+                ->with('countryRelation')
+                ->get(),
+            $radius
+        );
+
+        return response()->json([
+            'data' => [
+                'cities' => CityResource::collection($cities)->resolve(),
+                'provinces' => ProvinceResource::collection($provinces)->resolve(),
+            ],
+            'meta' => [
+                'city_count' => $cities->count(),
+                'province_count' => $provinces->count(),
+                'radius_km' => $radius,
+            ],
+        ]);
+    }
+
+    public function resolveUserCity(ResolveCityRequest $request): JsonResponse|CityResource
+    {
+        $data = $request->validated();
+        $latitude = (float) $data['latitude'];
+        $longitude = (float) $data['longitude'];
+        $maxDistance = array_key_exists('max_distance_km', $data) ? (float) $data['max_distance_km'] : self::DEFAULT_RADIUS_KM;
+
+        $city = $this
+            ->filterByRadius(
+                $this
+                    ->buildCityDistanceQuery($latitude, $longitude, $maxDistance)
+                    ->orderBy('distance_km')
+                    ->limit(1)
+                    ->with('provinceRelation.countryRelation')
+                    ->get(),
+                $maxDistance
+            )
+            ->first();
+
+        if ($city === null) {
+            return response()->json([
+                'message' => 'No city found within the specified distance.',
+            ], 404);
+        }
+
+        return CityResource::make($city)->additional([
+            'meta' => [
+                'distance_km' => round((float) $city->distance_km, 3),
+                'max_distance_km' => $maxDistance,
+            ],
+        ]);
+    }
+
+    public function nearbyCities(NearbyCitiesRequest $request): AnonymousResourceCollection
+    {
+        $data = $request->validated();
+        $latitude = (float) $data['latitude'];
+        $longitude = (float) $data['longitude'];
+        $radius = array_key_exists('radius_km', $data) ? (float) $data['radius_km'] : self::DEFAULT_RADIUS_KM;
+        $limit = (int) ($data['limit'] ?? self::DEFAULT_LIMIT);
+
+        $cities = $this->filterByRadius(
+            $this
+                ->buildCityDistanceQuery($latitude, $longitude, $radius)
+                ->orderBy('distance_km')
+                ->limit($limit)
+                ->with('provinceRelation.countryRelation')
+                ->get(),
+            $radius
+        );
+
+        return CityResource::collection($cities)->additional([
+            'meta' => [
+                'count' => $cities->count(),
+                'radius_km' => $radius,
+            ],
+        ]);
+    }
+
+    private function buildCityDistanceQuery(float $latitude, float $longitude, ?float $maxDistance = null): Builder
+    {
+        $distanceExpression = $this->distanceExpression('cities.latitude', 'cities.longitude');
+
+        $query = City::query()
+            ->select('cities.*')
+            ->selectRaw($distanceExpression . ' AS distance_km', [$latitude, $longitude, $latitude])
+            ->whereNotNull('latitude')
+            ->whereNotNull('longitude');
+
+        if ($maxDistance !== null) {
+            $query->whereRaw($distanceExpression . ' <= ?', [$latitude, $longitude, $latitude, $maxDistance]);
+        }
+
+        return $query;
+    }
+
+    private function buildProvinceDistanceQuery(float $latitude, float $longitude, ?float $maxDistance = null): Builder
+    {
+        $distanceExpression = $this->distanceExpression('provinces.latitude', 'provinces.longitude');
+
+        $query = Province::query()
+            ->select('provinces.*')
+            ->selectRaw($distanceExpression . ' AS distance_km', [$latitude, $longitude, $latitude])
+            ->whereNotNull('latitude')
+            ->whereNotNull('longitude');
+
+        if ($maxDistance !== null) {
+            $query->whereRaw($distanceExpression . ' <= ?', [$latitude, $longitude, $latitude, $maxDistance]);
+        }
+
+        return $query;
+    }
+
+    private function distanceExpression(string $latitudeColumn, string $longitudeColumn): string
+    {
+        return sprintf(
+            '6371 * ACOS(MIN(1, MAX(-1, COS(? * %3$f) * COS(%1$s * %3$f) * COS((%2$s - ?) * %3$f) + SIN(? * %3$f) * SIN(%1$s * %3$f))))',
+            $latitudeColumn,
+            $longitudeColumn,
+            self::DEGREE_TO_RADIAN
+        );
+    }
+
+    private function filterByRadius(Collection $items, ?float $maxDistance): Collection
+    {
+        if ($maxDistance === null) {
+            return $items->values();
+        }
+
+        return $items
+            ->filter(fn ($item) => isset($item->distance_km) && (float) $item->distance_km <= $maxDistance)
+            ->values();
+    }
+}

--- a/app/Http/Requests/Geography/LocationLookupRequest.php
+++ b/app/Http/Requests/Geography/LocationLookupRequest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Requests\Geography;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class LocationLookupRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'latitude' => ['required', 'numeric', 'between:-90,90'],
+            'longitude' => ['required', 'numeric', 'between:-180,180'],
+            'radius_km' => ['nullable', 'numeric', 'min:0', 'max:1000'],
+            'city_limit' => ['nullable', 'integer', 'min:1', 'max:100'],
+            'province_limit' => ['nullable', 'integer', 'min:1', 'max:100'],
+        ];
+    }
+}

--- a/app/Http/Requests/Geography/NearbyCitiesRequest.php
+++ b/app/Http/Requests/Geography/NearbyCitiesRequest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\Requests\Geography;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class NearbyCitiesRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'latitude' => ['required', 'numeric', 'between:-90,90'],
+            'longitude' => ['required', 'numeric', 'between:-180,180'],
+            'radius_km' => ['nullable', 'numeric', 'min:0', 'max:1000'],
+            'limit' => ['nullable', 'integer', 'min:1', 'max:100'],
+        ];
+    }
+}

--- a/app/Http/Requests/Geography/ResolveCityRequest.php
+++ b/app/Http/Requests/Geography/ResolveCityRequest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Requests\Geography;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class ResolveCityRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'latitude' => ['required', 'numeric', 'between:-90,90'],
+            'longitude' => ['required', 'numeric', 'between:-180,180'],
+            'max_distance_km' => ['nullable', 'numeric', 'min:0', 'max:1000'],
+        ];
+    }
+}

--- a/app/Http/Resources/CityResource.php
+++ b/app/Http/Resources/CityResource.php
@@ -16,6 +16,7 @@ class CityResource extends JsonResource
             'name_en' => $this->name_en,
             'latitude' => $this->latitude !== null ? (float) $this->latitude : null,
             'longitude' => $this->longitude !== null ? (float) $this->longitude : null,
+            'distance_km' => $this->when(isset($this->distance_km), round((float) $this->distance_km, 3)),
             'province' => ProvinceResource::make($this->whenLoaded('provinceRelation')),
         ];
     }

--- a/app/Http/Resources/ProvinceResource.php
+++ b/app/Http/Resources/ProvinceResource.php
@@ -14,6 +14,9 @@ class ProvinceResource extends JsonResource
             'country_id' => $this->country,
             'name' => $this->name,
             'name_en' => $this->name_en,
+            'latitude' => $this->latitude !== null ? (float) $this->latitude : null,
+            'longitude' => $this->longitude !== null ? (float) $this->longitude : null,
+            'distance_km' => $this->when(isset($this->distance_km), round((float) $this->distance_km, 3)),
             'country' => CountryResource::make($this->whenLoaded('countryRelation')),
             'cities' => CityResource::collection($this->whenLoaded('cities')),
         ];

--- a/app/Models/Province.php
+++ b/app/Models/Province.php
@@ -17,10 +17,14 @@ class Province extends Model
         'country',
         'name',
         'name_en',
+        'latitude',
+        'longitude',
     ];
 
     protected $casts = [
         'country' => 'int',
+        'latitude' => 'float',
+        'longitude' => 'float',
     ];
 
     public function countryRelation(): BelongsTo

--- a/database/migrations/2025_09_28_234743_add_coordinates_to_provinces_table.php
+++ b/database/migrations/2025_09_28_234743_add_coordinates_to_provinces_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('provinces', function (Blueprint $table) {
+            $table->decimal('latitude', 10, 8)->nullable()->after('name_en');
+            $table->decimal('longitude', 11, 8)->nullable()->after('latitude');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('provinces', function (Blueprint $table) {
+            $table->dropColumn(['latitude', 'longitude']);
+        });
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -2,6 +2,7 @@
 
 use App\Http\Controllers\Api\CityController;
 use App\Http\Controllers\Api\CountryController;
+use App\Http\Controllers\Api\GeolocationController;
 use App\Http\Controllers\Api\ProvinceController;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Route;
@@ -85,6 +86,10 @@ Route::prefix('geography')->group(function () {
 
     Route::get('cities', [CityController::class, 'index']);
     Route::get('cities/{city}', [CityController::class, 'show']);
+
+    Route::get('locations/lookup', [GeolocationController::class, 'lookup']);
+    Route::get('locations/user-city', [GeolocationController::class, 'resolveUserCity']);
+    Route::get('locations/nearby-cities', [GeolocationController::class, 'nearbyCities']);
 });
 
 

--- a/tests/Feature/Geography/Concerns/CreatesGeography.php
+++ b/tests/Feature/Geography/Concerns/CreatesGeography.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace Tests\Feature\Geography\Concerns;
+
+use App\Models\City;
+use App\Models\Country;
+use App\Models\Province;
+
+trait CreatesGeography
+{
+    protected function seedGeography(): array
+    {
+        $iran = Country::create([
+            'capital_city' => null,
+            'name' => 'ایران',
+            'name_en' => 'Iran',
+        ]);
+
+        $iraq = Country::create([
+            'capital_city' => null,
+            'name' => 'عراق',
+            'name_en' => 'Iraq',
+        ]);
+
+        $tehranProvince = Province::create([
+            'country' => $iran->id,
+            'name' => 'تهران',
+            'name_en' => 'Tehran',
+            'latitude' => 35.68920000,
+            'longitude' => 51.38900000,
+        ]);
+
+        $isfahanProvince = Province::create([
+            'country' => $iran->id,
+            'name' => 'اصفهان',
+            'name_en' => 'Isfahan',
+            'latitude' => 32.65250000,
+            'longitude' => 51.67460000,
+        ]);
+
+        $baghdadProvince = Province::create([
+            'country' => $iraq->id,
+            'name' => 'بغداد',
+            'name_en' => 'Baghdad',
+            'latitude' => 33.31520000,
+            'longitude' => 44.36610000,
+        ]);
+
+        $tehranCity = City::create([
+            'province' => $tehranProvince->id,
+            'name' => 'تهران',
+            'name_en' => 'Tehran',
+            'latitude' => 35.68920000,
+            'longitude' => 51.38900000,
+        ]);
+
+        $karajCity = City::create([
+            'province' => $tehranProvince->id,
+            'name' => 'کرج',
+            'name_en' => 'Karaj',
+            'latitude' => 35.83270000,
+            'longitude' => 50.99150000,
+        ]);
+
+        $isfahanCity = City::create([
+            'province' => $isfahanProvince->id,
+            'name' => 'اصفهان',
+            'name_en' => 'Isfahan',
+            'latitude' => 32.65250000,
+            'longitude' => 51.67460000,
+        ]);
+
+        $baghdadCity = City::create([
+            'province' => $baghdadProvince->id,
+            'name' => 'بغداد',
+            'name_en' => 'Baghdad',
+            'latitude' => 33.31520000,
+            'longitude' => 44.36610000,
+        ]);
+
+        $iran->update(['capital_city' => $tehranCity->id]);
+        $iraq->update(['capital_city' => $baghdadCity->id]);
+
+        return compact(
+            'iran',
+            'iraq',
+            'tehranProvince',
+            'isfahanProvince',
+            'baghdadProvince',
+            'tehranCity',
+            'karajCity',
+            'isfahanCity',
+            'baghdadCity'
+        );
+    }
+}

--- a/tests/Feature/Geography/GeographyApiTest.php
+++ b/tests/Feature/Geography/GeographyApiTest.php
@@ -2,15 +2,14 @@
 
 namespace Tests\Feature\Geography;
 
-use App\Models\City;
-use App\Models\Country;
-use App\Models\Province;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\Feature\Geography\Concerns\CreatesGeography;
 use Tests\TestCase;
 
 class GeographyApiTest extends TestCase
 {
     use RefreshDatabase;
+    use CreatesGeography;
 
     public function test_can_list_countries_with_filters(): void
     {
@@ -104,83 +103,4 @@ class GeographyApiTest extends TestCase
             ->assertJsonPath('meta.total', 2);
     }
 
-    private function seedGeography(): array
-    {
-        $iran = Country::create([
-            'capital_city' => null,
-            'name' => 'ایران',
-            'name_en' => 'Iran',
-        ]);
-
-        $iraq = Country::create([
-            'capital_city' => null,
-            'name' => 'عراق',
-            'name_en' => 'Iraq',
-        ]);
-
-        $tehranProvince = Province::create([
-            'country' => $iran->id,
-            'name' => 'تهران',
-            'name_en' => 'Tehran',
-        ]);
-
-        $isfahanProvince = Province::create([
-            'country' => $iran->id,
-            'name' => 'اصفهان',
-            'name_en' => 'Isfahan',
-        ]);
-
-        $baghdadProvince = Province::create([
-            'country' => $iraq->id,
-            'name' => 'بغداد',
-            'name_en' => 'Baghdad',
-        ]);
-
-        $tehranCity = City::create([
-            'province' => $tehranProvince->id,
-            'name' => 'تهران',
-            'name_en' => 'Tehran',
-            'latitude' => 35.68920000,
-            'longitude' => 51.38900000,
-        ]);
-
-        $karajCity = City::create([
-            'province' => $tehranProvince->id,
-            'name' => 'کرج',
-            'name_en' => 'Karaj',
-            'latitude' => 35.83270000,
-            'longitude' => 50.99150000,
-        ]);
-
-        $isfahanCity = City::create([
-            'province' => $isfahanProvince->id,
-            'name' => 'اصفهان',
-            'name_en' => 'Isfahan',
-            'latitude' => 32.65250000,
-            'longitude' => 51.67460000,
-        ]);
-
-        $baghdadCity = City::create([
-            'province' => $baghdadProvince->id,
-            'name' => 'بغداد',
-            'name_en' => 'Baghdad',
-            'latitude' => 33.31520000,
-            'longitude' => 44.36610000,
-        ]);
-
-        $iran->update(['capital_city' => $tehranCity->id]);
-        $iraq->update(['capital_city' => $baghdadCity->id]);
-
-        return compact(
-            'iran',
-            'iraq',
-            'tehranProvince',
-            'isfahanProvince',
-            'baghdadProvince',
-            'tehranCity',
-            'karajCity',
-            'isfahanCity',
-            'baghdadCity'
-        );
-    }
 }

--- a/tests/Feature/Geography/GeolocationApiTest.php
+++ b/tests/Feature/Geography/GeolocationApiTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Tests\Feature\Geography;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Testing\Fluent\AssertableJson;
+use Tests\Feature\Geography\Concerns\CreatesGeography;
+use Tests\TestCase;
+
+class GeolocationApiTest extends TestCase
+{
+    use RefreshDatabase;
+    use CreatesGeography;
+
+    public function test_can_lookup_locations_by_coordinates(): void
+    {
+        $data = $this->seedGeography();
+
+        $response = $this->getJson('/api/geography/locations/lookup?latitude=35.7&longitude=51.4&radius_km=80&city_limit=5&province_limit=5');
+
+        $response
+            ->assertOk()
+            ->assertJson(function (AssertableJson $json) use ($data) {
+                $json
+                    ->where('meta.city_count', 2)
+                    ->where('meta.province_count', 1)
+                    ->where('data.cities.0.id', $data['tehranCity']->id)
+                    ->where('data.provinces.0.id', $data['tehranProvince']->id)
+                    ->has('data.cities.0.distance_km')
+                    ->has('data.provinces.0.distance_km');
+            });
+    }
+
+    public function test_can_resolve_user_city_by_coordinates(): void
+    {
+        $data = $this->seedGeography();
+
+        $response = $this->getJson('/api/geography/locations/user-city?latitude=35.7&longitude=51.4&max_distance_km=80');
+
+        $response
+            ->assertOk()
+            ->assertJson(function (AssertableJson $json) use ($data) {
+                $json
+                    ->where('data.id', $data['tehranCity']->id)
+                    ->where('data.name_en', 'Tehran')
+                    ->where('meta.max_distance_km', fn ($value) => (float) $value === 80.0)
+                    ->where('meta.distance_km', fn ($distance) => $distance < 15);
+            });
+    }
+
+    public function test_can_list_nearby_cities_sorted_by_distance(): void
+    {
+        $this->seedGeography();
+
+        $response = $this->getJson('/api/geography/locations/nearby-cities?latitude=35.7&longitude=51.4&radius_km=400&limit=3');
+
+        $response
+            ->assertOk()
+            ->assertJson(function (AssertableJson $json) {
+                $json
+                    ->has('data', 3)
+                    ->where('data.0.name_en', 'Tehran')
+                    ->where('data.1.name_en', 'Karaj')
+                    ->where('data.2.name_en', 'Isfahan')
+                    ->where('meta.count', 3)
+                    ->where('meta.radius_km', fn ($value) => (float) $value === 400.0)
+                    ->where('data.0.distance_km', fn ($distance) => $distance < 15);
+            });
+    }
+}


### PR DESCRIPTION
## Summary
- add a dedicated geolocation controller that resolves nearby cities and provinces and powers the requested endpoints
- extend requests, resources, models, and migrations to support latitude/longitude metadata for provinces and distance outputs
- add reusable geography test fixtures and feature tests that cover the new APIs

## Testing
- ./vendor/bin/phpunit tests/Feature/Geography/GeolocationApiTest.php
- ./vendor/bin/phpunit tests/Feature/Geography/GeographyApiTest.php

------
https://chatgpt.com/codex/tasks/task_e_68d9c8b190ec832bb8254cd530b42168