### PR TITLE
feat: introduce ads module scaffolding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 /.zed
 /auth.json
 /node_modules
+Modules/*/node_modules
 /public/build
 /public/hot
 /public/storage

--- a/Modules/Ad/app/Http/Controllers/AdAttributeDefinitionController.php
+++ b/Modules/Ad/app/Http/Controllers/AdAttributeDefinitionController.php
@@ -12,8 +12,24 @@ use Modules\Ad\Http\Requests\AdAttributeDefinition\UpdateAdAttributeDefinitionRe
 use Modules\Ad\Http\Resources\AdAttributeDefinitionResource;
 use Modules\Ad\Models\AdAttributeDefinition;
 
+/**
+ * @group Ad Attribute Definitions
+ *
+ * Manage individual attribute definitions assigned to advertisable entities.
+ */
 class AdAttributeDefinitionController extends Controller
 {
+    /**
+     * List attribute definitions
+     *
+     * @group Ad Attribute Definitions
+     *
+     * Retrieve attribute definitions optionally filtered by group.
+     *
+     * @queryParam group_id integer Limit results to a specific attribute group. Example: 4
+     * @queryParam per_page integer Number of results per page, up to 200. Example: 25
+     * @queryParam without_pagination boolean Set to true to return all definitions without pagination. Example: false
+     */
     public function index(Request $request): AnonymousResourceCollection
     {
         $query = AdAttributeDefinition::query()
@@ -31,6 +47,13 @@ class AdAttributeDefinitionController extends Controller
         );
     }
 
+    /**
+     * Create an attribute definition
+     *
+     * @group Ad Attribute Definitions
+     *
+     * Persist a new attribute definition for dynamic ad data.
+     */
     public function store(StoreAdAttributeDefinitionRequest $request): JsonResponse
     {
         $definition = AdAttributeDefinition::create($request->validated());
@@ -38,11 +61,25 @@ class AdAttributeDefinitionController extends Controller
         return (new AdAttributeDefinitionResource($definition))->response()->setStatusCode(Response::HTTP_CREATED);
     }
 
+    /**
+     * Show an attribute definition
+     *
+     * @group Ad Attribute Definitions
+     *
+     * Retrieve a single attribute definition with metadata.
+     */
     public function show(AdAttributeDefinition $adAttributeDefinition): AdAttributeDefinitionResource
     {
         return new AdAttributeDefinitionResource($adAttributeDefinition);
     }
 
+    /**
+     * Update an attribute definition
+     *
+     * @group Ad Attribute Definitions
+     *
+     * Apply changes to an existing attribute definition.
+     */
     public function update(UpdateAdAttributeDefinitionRequest $request, AdAttributeDefinition $adAttributeDefinition): AdAttributeDefinitionResource
     {
         $adAttributeDefinition->fill($request->validated());
@@ -51,6 +88,13 @@ class AdAttributeDefinitionController extends Controller
         return new AdAttributeDefinitionResource($adAttributeDefinition);
     }
 
+    /**
+     * Delete an attribute definition
+     *
+     * @group Ad Attribute Definitions
+     *
+     * Remove the specified attribute definition.
+     */
     public function destroy(AdAttributeDefinition $adAttributeDefinition): Response
     {
         $adAttributeDefinition->delete();

--- a/Modules/Ad/app/Http/Controllers/AdAttributeDefinitionController.php
+++ b/Modules/Ad/app/Http/Controllers/AdAttributeDefinitionController.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Modules\Ad\Http\Controllers;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
+use Modules\Ad\Http\Requests\AdAttributeDefinition\StoreAdAttributeDefinitionRequest;
+use Modules\Ad\Http\Requests\AdAttributeDefinition\UpdateAdAttributeDefinitionRequest;
+use Modules\Ad\Http\Resources\AdAttributeDefinitionResource;
+use Modules\Ad\Models\AdAttributeDefinition;
+
+class AdAttributeDefinitionController extends Controller
+{
+    public function index(Request $request): AnonymousResourceCollection
+    {
+        $query = AdAttributeDefinition::query()
+            ->when($request->filled('group_id'), fn ($q) => $q->where('group_id', $request->input('group_id')))
+            ->orderBy('id');
+
+        if ($request->boolean('without_pagination')) {
+            return AdAttributeDefinitionResource::collection($query->get());
+        }
+
+        $perPage = (int) min($request->integer('per_page', 25), 200);
+
+        return AdAttributeDefinitionResource::collection(
+            $query->paginate($perPage)->appends($request->query())
+        );
+    }
+
+    public function store(StoreAdAttributeDefinitionRequest $request): JsonResponse
+    {
+        $definition = AdAttributeDefinition::create($request->validated());
+
+        return (new AdAttributeDefinitionResource($definition))->response()->setStatusCode(Response::HTTP_CREATED);
+    }
+
+    public function show(AdAttributeDefinition $adAttributeDefinition): AdAttributeDefinitionResource
+    {
+        return new AdAttributeDefinitionResource($adAttributeDefinition);
+    }
+
+    public function update(UpdateAdAttributeDefinitionRequest $request, AdAttributeDefinition $adAttributeDefinition): AdAttributeDefinitionResource
+    {
+        $adAttributeDefinition->fill($request->validated());
+        $adAttributeDefinition->save();
+
+        return new AdAttributeDefinitionResource($adAttributeDefinition);
+    }
+
+    public function destroy(AdAttributeDefinition $adAttributeDefinition): Response
+    {
+        $adAttributeDefinition->delete();
+
+        return response()->noContent();
+    }
+}

--- a/Modules/Ad/app/Http/Controllers/AdAttributeGroupController.php
+++ b/Modules/Ad/app/Http/Controllers/AdAttributeGroupController.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Modules\Ad\Http\Controllers;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
+use Modules\Ad\Http\Requests\AdAttributeGroup\StoreAdAttributeGroupRequest;
+use Modules\Ad\Http\Requests\AdAttributeGroup\UpdateAdAttributeGroupRequest;
+use Modules\Ad\Http\Resources\AdAttributeGroupResource;
+use Modules\Ad\Models\AdAttributeGroup;
+
+class AdAttributeGroupController extends Controller
+{
+    public function index(Request $request): AnonymousResourceCollection
+    {
+        $query = AdAttributeGroup::query()
+            ->when($request->filled('advertisable_type'), fn ($q) => $q->where('advertisable_type', $request->input('advertisable_type')))
+            ->when($request->filled('category_id'), fn ($q) => $q->where('category_id', $request->input('category_id')))
+            ->orderBy('display_order')
+            ->orderBy('id');
+
+        if ($request->boolean('without_pagination')) {
+            return AdAttributeGroupResource::collection($query->get());
+        }
+
+        $perPage = (int) min($request->integer('per_page', 25), 200);
+
+        return AdAttributeGroupResource::collection(
+            $query->paginate($perPage)->appends($request->query())
+        );
+    }
+
+    public function store(StoreAdAttributeGroupRequest $request): JsonResponse
+    {
+        $group = AdAttributeGroup::create($request->validated());
+
+        return (new AdAttributeGroupResource($group))->response()->setStatusCode(Response::HTTP_CREATED);
+    }
+
+    public function show(AdAttributeGroup $adAttributeGroup): AdAttributeGroupResource
+    {
+        return new AdAttributeGroupResource($adAttributeGroup);
+    }
+
+    public function update(UpdateAdAttributeGroupRequest $request, AdAttributeGroup $adAttributeGroup): AdAttributeGroupResource
+    {
+        $adAttributeGroup->fill($request->validated());
+        $adAttributeGroup->save();
+
+        return new AdAttributeGroupResource($adAttributeGroup);
+    }
+
+    public function destroy(AdAttributeGroup $adAttributeGroup): Response
+    {
+        $adAttributeGroup->delete();
+
+        return response()->noContent();
+    }
+}

--- a/Modules/Ad/app/Http/Controllers/AdAttributeGroupController.php
+++ b/Modules/Ad/app/Http/Controllers/AdAttributeGroupController.php
@@ -12,8 +12,25 @@ use Modules\Ad\Http\Requests\AdAttributeGroup\UpdateAdAttributeGroupRequest;
 use Modules\Ad\Http\Resources\AdAttributeGroupResource;
 use Modules\Ad\Models\AdAttributeGroup;
 
+/**
+ * @group Ad Attribute Groups
+ *
+ * Manage groupings of dynamic attributes for advertisable entities.
+ */
 class AdAttributeGroupController extends Controller
 {
+    /**
+     * List attribute groups
+     *
+     * @group Ad Attribute Groups
+     *
+     * Retrieve attribute groups filtered by advertisable type or category.
+     *
+     * @queryParam advertisable_type string Filter by advertisable class name. Example: Modules\\Ad\\Models\\AdCar
+     * @queryParam category_id integer Filter groups scoped to the given category. Example: 8
+     * @queryParam per_page integer Number of results per page, up to 200. Example: 25
+     * @queryParam without_pagination boolean Set to true to return all groups without pagination. Example: false
+     */
     public function index(Request $request): AnonymousResourceCollection
     {
         $query = AdAttributeGroup::query()
@@ -33,6 +50,13 @@ class AdAttributeGroupController extends Controller
         );
     }
 
+    /**
+     * Create an attribute group
+     *
+     * @group Ad Attribute Groups
+     *
+     * Persist a new attribute group for organising attribute definitions.
+     */
     public function store(StoreAdAttributeGroupRequest $request): JsonResponse
     {
         $group = AdAttributeGroup::create($request->validated());
@@ -40,11 +64,25 @@ class AdAttributeGroupController extends Controller
         return (new AdAttributeGroupResource($group))->response()->setStatusCode(Response::HTTP_CREATED);
     }
 
+    /**
+     * Show an attribute group
+     *
+     * @group Ad Attribute Groups
+     *
+     * Retrieve details for a single attribute group.
+     */
     public function show(AdAttributeGroup $adAttributeGroup): AdAttributeGroupResource
     {
         return new AdAttributeGroupResource($adAttributeGroup);
     }
 
+    /**
+     * Update an attribute group
+     *
+     * @group Ad Attribute Groups
+     *
+     * Apply modifications to the specified attribute group.
+     */
     public function update(UpdateAdAttributeGroupRequest $request, AdAttributeGroup $adAttributeGroup): AdAttributeGroupResource
     {
         $adAttributeGroup->fill($request->validated());
@@ -53,6 +91,13 @@ class AdAttributeGroupController extends Controller
         return new AdAttributeGroupResource($adAttributeGroup);
     }
 
+    /**
+     * Delete an attribute group
+     *
+     * @group Ad Attribute Groups
+     *
+     * Remove the specified attribute group.
+     */
     public function destroy(AdAttributeGroup $adAttributeGroup): Response
     {
         $adAttributeGroup->delete();

--- a/Modules/Ad/app/Http/Controllers/AdAttributeValueController.php
+++ b/Modules/Ad/app/Http/Controllers/AdAttributeValueController.php
@@ -12,8 +12,26 @@ use Modules\Ad\Http\Requests\AdAttributeValue\UpdateAdAttributeValueRequest;
 use Modules\Ad\Http\Resources\AdAttributeValueResource;
 use Modules\Ad\Models\AdAttributeValue;
 
+/**
+ * @group Ad Attribute Values
+ *
+ * Manage stored values for dynamic advertisable attributes.
+ */
 class AdAttributeValueController extends Controller
 {
+    /**
+     * List attribute values
+     *
+     * @group Ad Attribute Values
+     *
+     * Retrieve attribute values filtered by definition or advertisable linkage.
+     *
+     * @queryParam definition_id integer Filter by attribute definition. Example: 12
+     * @queryParam advertisable_type string Filter by advertisable class name. Example: Modules\\Ad\\Models\\AdCar
+     * @queryParam advertisable_id integer Filter by advertisable identifier. Example: 34
+     * @queryParam per_page integer Number of results per page, up to 200. Example: 25
+     * @queryParam without_pagination boolean Set to true to return all values without pagination. Example: false
+     */
     public function index(Request $request): AnonymousResourceCollection
     {
         $query = AdAttributeValue::query()
@@ -34,6 +52,13 @@ class AdAttributeValueController extends Controller
         );
     }
 
+    /**
+     * Create an attribute value
+     *
+     * @group Ad Attribute Values
+     *
+     * Persist a new attribute value for an advertisable model.
+     */
     public function store(StoreAdAttributeValueRequest $request): JsonResponse
     {
         $value = AdAttributeValue::create($this->mapPayload($request->validated(), includeMissing: true))->load('definition');
@@ -41,11 +66,25 @@ class AdAttributeValueController extends Controller
         return (new AdAttributeValueResource($value))->response()->setStatusCode(Response::HTTP_CREATED);
     }
 
+    /**
+     * Show an attribute value
+     *
+     * @group Ad Attribute Values
+     *
+     * Retrieve an attribute value with its definition metadata.
+     */
     public function show(AdAttributeValue $adAttributeValue): AdAttributeValueResource
     {
         return new AdAttributeValueResource($adAttributeValue->load('definition'));
     }
 
+    /**
+     * Update an attribute value
+     *
+     * @group Ad Attribute Values
+     *
+     * Apply updates to an existing attribute value.
+     */
     public function update(UpdateAdAttributeValueRequest $request, AdAttributeValue $adAttributeValue): AdAttributeValueResource
     {
         $adAttributeValue->fill($this->mapPayload($request->validated(), includeMissing: false));
@@ -55,6 +94,13 @@ class AdAttributeValueController extends Controller
         return new AdAttributeValueResource($adAttributeValue);
     }
 
+    /**
+     * Delete an attribute value
+     *
+     * @group Ad Attribute Values
+     *
+     * Remove the specified attribute value record.
+     */
     public function destroy(AdAttributeValue $adAttributeValue): Response
     {
         $adAttributeValue->delete();

--- a/Modules/Ad/app/Http/Controllers/AdAttributeValueController.php
+++ b/Modules/Ad/app/Http/Controllers/AdAttributeValueController.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Modules\Ad\Http\Controllers;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
+use Modules\Ad\Http\Requests\AdAttributeValue\StoreAdAttributeValueRequest;
+use Modules\Ad\Http\Requests\AdAttributeValue\UpdateAdAttributeValueRequest;
+use Modules\Ad\Http\Resources\AdAttributeValueResource;
+use Modules\Ad\Models\AdAttributeValue;
+
+class AdAttributeValueController extends Controller
+{
+    public function index(Request $request): AnonymousResourceCollection
+    {
+        $query = AdAttributeValue::query()
+            ->with('definition')
+            ->when($request->filled('definition_id'), fn ($q) => $q->where('definition_id', $request->input('definition_id')))
+            ->when($request->filled('advertisable_type'), fn ($q) => $q->where('advertisable_type', $request->input('advertisable_type')))
+            ->when($request->filled('advertisable_id'), fn ($q) => $q->where('advertisable_id', $request->input('advertisable_id')))
+            ->orderByDesc('updated_at');
+
+        if ($request->boolean('without_pagination')) {
+            return AdAttributeValueResource::collection($query->get());
+        }
+
+        $perPage = (int) min($request->integer('per_page', 25), 200);
+
+        return AdAttributeValueResource::collection(
+            $query->paginate($perPage)->appends($request->query())
+        );
+    }
+
+    public function store(StoreAdAttributeValueRequest $request): JsonResponse
+    {
+        $value = AdAttributeValue::create($this->mapPayload($request->validated(), includeMissing: true))->load('definition');
+
+        return (new AdAttributeValueResource($value))->response()->setStatusCode(Response::HTTP_CREATED);
+    }
+
+    public function show(AdAttributeValue $adAttributeValue): AdAttributeValueResource
+    {
+        return new AdAttributeValueResource($adAttributeValue->load('definition'));
+    }
+
+    public function update(UpdateAdAttributeValueRequest $request, AdAttributeValue $adAttributeValue): AdAttributeValueResource
+    {
+        $adAttributeValue->fill($this->mapPayload($request->validated(), includeMissing: false));
+        $adAttributeValue->save();
+        $adAttributeValue->load('definition');
+
+        return new AdAttributeValueResource($adAttributeValue);
+    }
+
+    public function destroy(AdAttributeValue $adAttributeValue): Response
+    {
+        $adAttributeValue->delete();
+
+        return response()->noContent();
+    }
+
+    private function mapPayload(array $payload, bool $includeMissing): array
+    {
+        $columns = [
+            'definition_id',
+            'advertisable_type',
+            'advertisable_id',
+            'value_string',
+            'value_integer',
+            'value_decimal',
+            'value_boolean',
+            'value_json',
+            'normalized_value',
+        ];
+
+        $result = [];
+
+        foreach ($columns as $column) {
+            if (array_key_exists($column, $payload)) {
+                $result[$column] = $payload[$column];
+            } elseif ($includeMissing && ! in_array($column, ['definition_id', 'advertisable_type', 'advertisable_id'], true)) {
+                $result[$column] = null;
+            }
+        }
+
+        return $result;
+    }
+}

--- a/Modules/Ad/app/Http/Controllers/AdCategoryController.php
+++ b/Modules/Ad/app/Http/Controllers/AdCategoryController.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Modules\Ad\Http\Controllers;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
+use Illuminate\Support\Facades\DB;
+use Modules\Ad\Http\Requests\AdCategory\StoreAdCategoryRequest;
+use Modules\Ad\Http\Requests\AdCategory\UpdateAdCategoryRequest;
+use Modules\Ad\Http\Resources\AdCategoryResource;
+use Modules\Ad\Models\AdCategory;
+use Modules\Ad\Services\CategoryHierarchyManager;
+
+class AdCategoryController extends Controller
+{
+    public function __construct(private readonly CategoryHierarchyManager $hierarchyManager)
+    {
+    }
+
+    public function index(Request $request): AnonymousResourceCollection
+    {
+        $query = AdCategory::query()
+            ->when($request->filled('parent_id'), fn ($q) => $q->where('parent_id', $request->input('parent_id')))
+            ->when($request->boolean('only_active'), fn ($q) => $q->where('is_active', true))
+            ->when($request->filled('search'), function ($q) use ($request) {
+                $search = $request->input('search');
+
+                $q->where(function ($inner) use ($search) {
+                    $inner->where('name', 'like', "%{$search}%")
+                        ->orWhere('slug', 'like', "%{$search}%");
+                });
+            })
+            ->orderBy('sort_order')
+            ->orderBy('name');
+
+        if ($request->boolean('without_pagination')) {
+            return AdCategoryResource::collection($query->get());
+        }
+
+        $perPage = (int) min($request->integer('per_page', 50), 200);
+
+        return AdCategoryResource::collection(
+            $query->paginate($perPage)->appends($request->query())
+        );
+    }
+
+    public function store(StoreAdCategoryRequest $request): JsonResponse
+    {
+        $payload = $request->validated();
+
+        /** @var AdCategory $category */
+        $category = DB::transaction(function () use ($payload) {
+            $category = AdCategory::create($payload);
+            $this->hierarchyManager->handleCreated($category);
+
+            return $category->fresh();
+        });
+
+        return (new AdCategoryResource($category))->response()->setStatusCode(Response::HTTP_CREATED);
+    }
+
+    public function show(AdCategory $adCategory): AdCategoryResource
+    {
+        return new AdCategoryResource($adCategory);
+    }
+
+    public function update(UpdateAdCategoryRequest $request, AdCategory $adCategory): AdCategoryResource
+    {
+        $payload = $request->validated();
+
+        /** @var AdCategory $category */
+        $category = DB::transaction(function () use ($adCategory, $payload) {
+            $adCategory->fill($payload);
+            $adCategory->save();
+
+            $this->hierarchyManager->rebuildSubtree($adCategory);
+
+            return $adCategory->fresh();
+        });
+
+        return new AdCategoryResource($category);
+    }
+
+    public function destroy(AdCategory $adCategory): Response
+    {
+        $adCategory->delete();
+
+        return response()->noContent();
+    }
+}

--- a/Modules/Ad/app/Http/Controllers/AdCategoryController.php
+++ b/Modules/Ad/app/Http/Controllers/AdCategoryController.php
@@ -14,12 +14,30 @@ use Modules\Ad\Http\Resources\AdCategoryResource;
 use Modules\Ad\Models\AdCategory;
 use Modules\Ad\Services\CategoryHierarchyManager;
 
+/**
+ * @group Ad Categories
+ *
+ * Manage the hierarchical taxonomy used to organise ads.
+ */
 class AdCategoryController extends Controller
 {
     public function __construct(private readonly CategoryHierarchyManager $hierarchyManager)
     {
     }
 
+    /**
+     * List ad categories
+     *
+     * @group Ad Categories
+     *
+     * Fetch categories with optional filtering by parent, activation state, or search term.
+     *
+     * @queryParam parent_id integer Filter categories by parent identifier. Example: 1
+     * @queryParam only_active boolean Return only active categories. Example: true
+     * @queryParam search string Search by category name or slug. Example: vehicles
+     * @queryParam per_page integer Number of results per page, up to 200. Example: 50
+     * @queryParam without_pagination boolean Set to true to receive all categories without pagination. Example: false
+     */
     public function index(Request $request): AnonymousResourceCollection
     {
         $query = AdCategory::query()
@@ -47,6 +65,13 @@ class AdCategoryController extends Controller
         );
     }
 
+    /**
+     * Create a category
+     *
+     * @group Ad Categories
+     *
+     * Store a new category and rebuild the hierarchy metadata.
+     */
     public function store(StoreAdCategoryRequest $request): JsonResponse
     {
         $payload = $request->validated();
@@ -62,11 +87,25 @@ class AdCategoryController extends Controller
         return (new AdCategoryResource($category))->response()->setStatusCode(Response::HTTP_CREATED);
     }
 
+    /**
+     * Show a category
+     *
+     * @group Ad Categories
+     *
+     * Retrieve details for the given category record.
+     */
     public function show(AdCategory $adCategory): AdCategoryResource
     {
         return new AdCategoryResource($adCategory);
     }
 
+    /**
+     * Update a category
+     *
+     * @group Ad Categories
+     *
+     * Apply updates and recompute the category hierarchy when relationships change.
+     */
     public function update(UpdateAdCategoryRequest $request, AdCategory $adCategory): AdCategoryResource
     {
         $payload = $request->validated();
@@ -84,6 +123,13 @@ class AdCategoryController extends Controller
         return new AdCategoryResource($category);
     }
 
+    /**
+     * Delete a category
+     *
+     * @group Ad Categories
+     *
+     * Soft delete the specified category.
+     */
     public function destroy(AdCategory $adCategory): Response
     {
         $adCategory->delete();

--- a/Modules/Ad/app/Http/Controllers/AdController.php
+++ b/Modules/Ad/app/Http/Controllers/AdController.php
@@ -13,8 +13,28 @@ use Modules\Ad\Http\Requests\Ad\UpdateAdRequest;
 use Modules\Ad\Http\Resources\AdResource;
 use Modules\Ad\Models\Ad;
 
+/**
+ * @group Ads
+ *
+ * Endpoints for managing advertisement listings.
+ */
 class AdController extends Controller
 {
+    /**
+     * List ads
+     *
+     * @group Ads
+     *
+     * Retrieve a filtered or paginated list of ads.
+     *
+     * @queryParam status string Filter by lifecycle status. Example: published
+     * @queryParam user_id integer Filter by owner user ID. Example: 12
+     * @queryParam category_id integer Limit to ads attached to the provided category. Example: 5
+     * @queryParam search string Search within title and description text. Example: sedan
+     * @queryParam only_published boolean Return only published records when true. Example: true
+     * @queryParam per_page integer Number of results per page, up to 100. Example: 25
+     * @queryParam without_pagination boolean Set to true to return all records without pagination. Example: false
+     */
     public function index(Request $request): AnonymousResourceCollection
     {
         $query = Ad::query()
@@ -50,6 +70,13 @@ class AdController extends Controller
         );
     }
 
+    /**
+     * Create an ad
+     *
+     * @group Ads
+     *
+     * Store a new ad and attach optional category assignments.
+     */
     public function store(StoreAdRequest $request): JsonResponse
     {
         $payload = collect($request->validated());
@@ -66,6 +93,13 @@ class AdController extends Controller
         return (new AdResource($ad))->response()->setStatusCode(Response::HTTP_CREATED);
     }
 
+    /**
+     * Show ad details
+     *
+     * @group Ads
+     *
+     * Retrieve the complete information for a single ad.
+     */
     public function show(Ad $ad): AdResource
     {
         $ad->load(['categories', 'advertisable']);
@@ -73,6 +107,13 @@ class AdController extends Controller
         return new AdResource($ad);
     }
 
+    /**
+     * Update an ad
+     *
+     * @group Ads
+     *
+     * Apply updates to an existing ad, optionally recording status and slug history.
+     */
     public function update(UpdateAdRequest $request, Ad $ad): AdResource
     {
         $payload = collect($request->validated());
@@ -115,6 +156,13 @@ class AdController extends Controller
         return new AdResource($ad);
     }
 
+    /**
+     * Delete an ad
+     *
+     * @group Ads
+     *
+     * Soft delete the specified ad.
+     */
     public function destroy(Ad $ad): Response
     {
         $ad->delete();

--- a/Modules/Ad/app/Http/Controllers/AdController.php
+++ b/Modules/Ad/app/Http/Controllers/AdController.php
@@ -1,0 +1,144 @@
+<?php
+
+namespace Modules\Ad\Http\Controllers;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
+use Illuminate\Support\Facades\DB;
+use Modules\Ad\Http\Requests\Ad\StoreAdRequest;
+use Modules\Ad\Http\Requests\Ad\UpdateAdRequest;
+use Modules\Ad\Http\Resources\AdResource;
+use Modules\Ad\Models\Ad;
+
+class AdController extends Controller
+{
+    public function index(Request $request): AnonymousResourceCollection
+    {
+        $query = Ad::query()
+            ->with(['categories', 'advertisable'])
+            ->when($request->filled('status'), fn ($q) => $q->where('status', $request->input('status')))
+            ->when($request->filled('user_id'), fn ($q) => $q->where('user_id', $request->input('user_id')))
+            ->when($request->filled('category_id'), function ($q) use ($request) {
+                $q->whereHas('categories', function ($categoryQuery) use ($request) {
+                    $categoryQuery->where('ad_categories.id', $request->input('category_id'));
+                });
+            })
+            ->when($request->filled('search'), function ($q) use ($request) {
+                $search = $request->input('search');
+
+                $q->where(function ($inner) use ($search) {
+                    $inner->where('title', 'like', "%{$search}%")
+                        ->orWhere('description', 'like', "%{$search}%");
+                });
+            })
+            ->when($request->boolean('only_published'), function ($q) {
+                $q->where('status', 'published');
+            })
+            ->orderByDesc('created_at');
+
+        $perPage = (int) min($request->integer('per_page', 15), 100);
+
+        if ($request->boolean('without_pagination')) {
+            return AdResource::collection($query->get());
+        }
+
+        return AdResource::collection(
+            $query->paginate($perPage)->appends($request->query())
+        );
+    }
+
+    public function store(StoreAdRequest $request): JsonResponse
+    {
+        $payload = collect($request->validated());
+        $categories = $payload->pull('categories', []);
+
+        /** @var Ad $ad */
+        $ad = DB::transaction(function () use ($payload, $categories) {
+            $ad = Ad::create($payload->toArray());
+            $this->syncCategories($ad, $categories);
+
+            return $ad->load(['categories', 'advertisable']);
+        });
+
+        return (new AdResource($ad))->response()->setStatusCode(Response::HTTP_CREATED);
+    }
+
+    public function show(Ad $ad): AdResource
+    {
+        $ad->load(['categories', 'advertisable']);
+
+        return new AdResource($ad);
+    }
+
+    public function update(UpdateAdRequest $request, Ad $ad): AdResource
+    {
+        $payload = collect($request->validated());
+        $categories = $payload->pull('categories', null);
+        $statusNote = $payload->pull('status_note');
+        $statusMetadata = $payload->pull('status_metadata');
+
+        $previousStatus = $ad->status;
+        $previousSlug = $ad->slug;
+
+        /** @var Ad $ad */
+        $ad = DB::transaction(function () use ($ad, $payload, $categories, $previousStatus, $previousSlug, $statusNote, $statusMetadata, $request) {
+            $ad->fill($payload->toArray());
+            $ad->save();
+
+            if ($categories !== null) {
+                $this->syncCategories($ad, $categories);
+            }
+
+            if ($previousSlug !== $ad->slug) {
+                $ad->slugHistories()->create([
+                    'slug' => $previousSlug,
+                    'redirect_to_slug' => $ad->slug,
+                ]);
+            }
+
+            if ($previousStatus !== $ad->status) {
+                $ad->statusHistories()->create([
+                    'from_status' => $previousStatus,
+                    'to_status' => $ad->status,
+                    'changed_by' => optional($request->user())->id,
+                    'notes' => $statusNote,
+                    'metadata' => $statusMetadata,
+                ]);
+            }
+
+            return $ad->load(['categories', 'advertisable']);
+        });
+
+        return new AdResource($ad);
+    }
+
+    public function destroy(Ad $ad): Response
+    {
+        $ad->delete();
+
+        return response()->noContent();
+    }
+
+    private function syncCategories(Ad $ad, array $categories): void
+    {
+        $payload = collect($categories)->mapWithKeys(function ($category) {
+            $categoryId = (int) data_get($category, 'id');
+
+            return [$categoryId => [
+                'is_primary' => (bool) data_get($category, 'is_primary', false),
+                'assigned_by' => data_get($category, 'assigned_by'),
+            ]];
+        })->all();
+
+        if (empty($payload)) {
+            $ad->categories()->detach();
+
+            return;
+        }
+
+        $ad->categories()->sync($payload);
+    }
+}

--- a/Modules/Ad/app/Http/Requests/Ad/StoreAdRequest.php
+++ b/Modules/Ad/app/Http/Requests/Ad/StoreAdRequest.php
@@ -79,6 +79,117 @@ class StoreAdRequest extends FormRequest
         });
     }
 
+    /**
+     * @return array<string, array<string, mixed>>
+     */
+    public function bodyParameters(): array
+    {
+        return [
+            'user_id' => [
+                'description' => 'Identifier of the ad owner.',
+                'example' => 42,
+            ],
+            'advertisable_type' => [
+                'description' => 'Fully qualified class name of the advertisable subtype.',
+                'example' => 'Modules\\Ad\\Models\\AdCar',
+            ],
+            'advertisable_id' => [
+                'description' => 'Identifier of the advertisable record.',
+                'example' => 10,
+            ],
+            'slug' => [
+                'description' => 'Unique slug for the ad.',
+                'example' => 'peugeot-206-2024',
+            ],
+            'title' => [
+                'description' => 'Headline displayed for the ad.',
+                'example' => 'Peugeot 206 2024',
+            ],
+            'subtitle' => [
+                'description' => 'Optional subtitle or tagline.',
+                'example' => 'Full options, low mileage',
+            ],
+            'description' => [
+                'description' => 'Rich description of the listing.',
+                'example' => 'One owner, regularly serviced, ready to drive.',
+            ],
+            'status' => [
+                'description' => 'Lifecycle status for moderation.',
+                'example' => 'draft',
+            ],
+            'published_at' => [
+                'description' => 'Publication datetime in ISO 8601 format.',
+                'example' => '2024-05-01T08:00:00Z',
+            ],
+            'expires_at' => [
+                'description' => 'Optional expiration datetime in ISO 8601 format.',
+                'example' => '2024-06-01T08:00:00Z',
+            ],
+            'price_amount' => [
+                'description' => 'Price stored in the smallest currency unit.',
+                'example' => 450000000,
+            ],
+            'price_currency' => [
+                'description' => 'Three-letter ISO currency code.',
+                'example' => 'IRR',
+            ],
+            'is_negotiable' => [
+                'description' => 'Indicates if the price can be negotiated.',
+                'example' => true,
+            ],
+            'is_exchangeable' => [
+                'description' => 'Indicates if swaps are accepted.',
+                'example' => false,
+            ],
+            'city_id' => [
+                'description' => 'City identifier for the ad location.',
+                'example' => 3,
+            ],
+            'province_id' => [
+                'description' => 'Province identifier for the ad location.',
+                'example' => 1,
+            ],
+            'latitude' => [
+                'description' => 'Latitude coordinate of the listing.',
+                'example' => 35.6892,
+            ],
+            'longitude' => [
+                'description' => 'Longitude coordinate of the listing.',
+                'example' => 51.3890,
+            ],
+            'contact_channel' => [
+                'description' => 'Contact details such as phone or messenger usernames.',
+                'example' => ['phone' => '123456789'],
+            ],
+            'view_count' => [
+                'description' => 'Pre-set view counter value, typically managed internally.',
+                'example' => 0,
+            ],
+            'share_count' => [
+                'description' => 'Pre-set share counter value, typically managed internally.',
+                'example' => 0,
+            ],
+            'favorite_count' => [
+                'description' => 'Pre-set favorite counter value, typically managed internally.',
+                'example' => 0,
+            ],
+            'featured_until' => [
+                'description' => 'Datetime until which the ad remains featured.',
+                'example' => '2024-05-15T08:00:00Z',
+            ],
+            'priority_score' => [
+                'description' => 'Numeric score affecting ordering.',
+                'example' => 12.5,
+            ],
+            'categories' => [
+                'description' => 'Array of category assignments.',
+                'example' => [
+                    ['id' => 7, 'is_primary' => true, 'assigned_by' => 42],
+                ],
+            ],
+        ];
+    }
+
     private function toBoolean(mixed $value): ?bool
     {
         if ($value === null) {

--- a/Modules/Ad/app/Http/Requests/Ad/StoreAdRequest.php
+++ b/Modules/Ad/app/Http/Requests/Ad/StoreAdRequest.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Modules\Ad\Http\Requests\Ad;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Validation\Rule;
+use Modules\Ad\Models\Ad;
+use Modules\Ad\Support\AdvertisableType;
+
+class StoreAdRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        $statusValues = ['draft', 'pending_review', 'published', 'rejected', 'archived', 'expired'];
+
+        return [
+            'user_id' => ['required', 'exists:users,id'],
+            'advertisable_type' => ['required', 'string', Rule::in(AdvertisableType::allowed())],
+            'advertisable_id' => ['required', 'integer'],
+            'slug' => ['required', 'string', 'max:255', 'alpha_dash', Rule::unique((new Ad())->getTable(), 'slug')],
+            'title' => ['required', 'string', 'max:255'],
+            'subtitle' => ['nullable', 'string', 'max:255'],
+            'description' => ['nullable', 'string'],
+            'status' => ['nullable', 'string', Rule::in($statusValues)],
+            'published_at' => ['nullable', 'date'],
+            'expires_at' => ['nullable', 'date', 'after_or_equal:published_at'],
+            'price_amount' => ['nullable', 'integer'],
+            'price_currency' => ['nullable', 'string', 'size:3'],
+            'is_negotiable' => ['boolean'],
+            'is_exchangeable' => ['boolean'],
+            'city_id' => ['nullable', 'exists:cities,id'],
+            'province_id' => ['nullable', 'exists:provinces,id'],
+            'latitude' => ['nullable', 'numeric', 'between:-90,90'],
+            'longitude' => ['nullable', 'numeric', 'between:-180,180'],
+            'contact_channel' => ['nullable', 'array'],
+            'view_count' => ['nullable', 'integer', 'min:0'],
+            'share_count' => ['nullable', 'integer', 'min:0'],
+            'favorite_count' => ['nullable', 'integer', 'min:0'],
+            'featured_until' => ['nullable', 'date'],
+            'priority_score' => ['nullable', 'numeric'],
+            'categories' => ['nullable', 'array'],
+            'categories.*.id' => ['required', 'integer', 'exists:ad_categories,id'],
+            'categories.*.is_primary' => ['nullable', 'boolean'],
+            'categories.*.assigned_by' => ['nullable', 'integer', 'exists:users,id'],
+        ];
+    }
+
+    public function prepareForValidation(): void
+    {
+        $this->merge([
+            'is_negotiable' => $this->toBoolean($this->input('is_negotiable')),
+            'is_exchangeable' => $this->toBoolean($this->input('is_exchangeable')),
+        ]);
+    }
+
+    public function withValidator($validator): void
+    {
+        $validator->after(function ($validator): void {
+            $type = $this->input('advertisable_type');
+            $advertisableId = $this->input('advertisable_id');
+
+            if (! AdvertisableType::isAllowed($type)) {
+                return;
+            }
+
+            $table = AdvertisableType::tableFor($type);
+
+            $exists = DB::table($table)->where('id', $advertisableId)->exists();
+
+            if (! $exists) {
+                $validator->errors()->add('advertisable_id', 'The selected advertisable does not exist.');
+            }
+        });
+    }
+
+    private function toBoolean(mixed $value): ?bool
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        return filter_var($value, FILTER_VALIDATE_BOOL, FILTER_NULL_ON_FAILURE);
+    }
+}

--- a/Modules/Ad/app/Http/Requests/Ad/UpdateAdRequest.php
+++ b/Modules/Ad/app/Http/Requests/Ad/UpdateAdRequest.php
@@ -92,6 +92,125 @@ class UpdateAdRequest extends FormRequest
         });
     }
 
+    /**
+     * @return array<string, array<string, mixed>>
+     */
+    public function bodyParameters(): array
+    {
+        return [
+            'user_id' => [
+                'description' => 'Identifier of the ad owner.',
+                'example' => 42,
+            ],
+            'advertisable_type' => [
+                'description' => 'Fully qualified class name of the advertisable subtype.',
+                'example' => 'Modules\\Ad\\Models\\AdCar',
+            ],
+            'advertisable_id' => [
+                'description' => 'Identifier of the advertisable record.',
+                'example' => 10,
+            ],
+            'slug' => [
+                'description' => 'Unique slug for the ad.',
+                'example' => 'peugeot-206-2024',
+            ],
+            'title' => [
+                'description' => 'Headline displayed for the ad.',
+                'example' => 'Peugeot 206 2024',
+            ],
+            'subtitle' => [
+                'description' => 'Optional subtitle or tagline.',
+                'example' => 'Full options, low mileage',
+            ],
+            'description' => [
+                'description' => 'Rich description of the listing.',
+                'example' => 'One owner, regularly serviced, ready to drive.',
+            ],
+            'status' => [
+                'description' => 'Lifecycle status for moderation.',
+                'example' => 'published',
+            ],
+            'published_at' => [
+                'description' => 'Publication datetime in ISO 8601 format.',
+                'example' => '2024-05-01T08:00:00Z',
+            ],
+            'expires_at' => [
+                'description' => 'Optional expiration datetime in ISO 8601 format.',
+                'example' => '2024-06-01T08:00:00Z',
+            ],
+            'price_amount' => [
+                'description' => 'Price stored in the smallest currency unit.',
+                'example' => 450000000,
+            ],
+            'price_currency' => [
+                'description' => 'Three-letter ISO currency code.',
+                'example' => 'IRR',
+            ],
+            'is_negotiable' => [
+                'description' => 'Indicates if the price can be negotiated.',
+                'example' => true,
+            ],
+            'is_exchangeable' => [
+                'description' => 'Indicates if swaps are accepted.',
+                'example' => false,
+            ],
+            'city_id' => [
+                'description' => 'City identifier for the ad location.',
+                'example' => 3,
+            ],
+            'province_id' => [
+                'description' => 'Province identifier for the ad location.',
+                'example' => 1,
+            ],
+            'latitude' => [
+                'description' => 'Latitude coordinate of the listing.',
+                'example' => 35.6892,
+            ],
+            'longitude' => [
+                'description' => 'Longitude coordinate of the listing.',
+                'example' => 51.3890,
+            ],
+            'contact_channel' => [
+                'description' => 'Contact details such as phone or messenger usernames.',
+                'example' => ['phone' => '123456789'],
+            ],
+            'view_count' => [
+                'description' => 'Pre-set view counter value, typically managed internally.',
+                'example' => 100,
+            ],
+            'share_count' => [
+                'description' => 'Pre-set share counter value, typically managed internally.',
+                'example' => 10,
+            ],
+            'favorite_count' => [
+                'description' => 'Pre-set favorite counter value, typically managed internally.',
+                'example' => 25,
+            ],
+            'featured_until' => [
+                'description' => 'Datetime until which the ad remains featured.',
+                'example' => '2024-05-15T08:00:00Z',
+            ],
+            'priority_score' => [
+                'description' => 'Numeric score affecting ordering.',
+                'example' => 12.5,
+            ],
+            'categories' => [
+                'description' => 'Array of category assignments.',
+                'example' => [
+                    ['id' => 7, 'is_primary' => true, 'assigned_by' => 42],
+                ],
+            ],
+            'status_note' => [
+                'description' => 'Optional note saved alongside status changes.',
+                'example' => 'Approved by moderator',
+            ],
+            'status_metadata' => [
+                'description' => 'Structured metadata explaining the status change.',
+                'example' => ['moderator' => 'system'],
+            ],
+        ];
+    }
+
     private function toBoolean(mixed $value): ?bool
     {
         if ($value === null) {

--- a/Modules/Ad/app/Http/Requests/Ad/UpdateAdRequest.php
+++ b/Modules/Ad/app/Http/Requests/Ad/UpdateAdRequest.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace Modules\Ad\Http\Requests\Ad;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Validation\Rule;
+use Modules\Ad\Models\Ad;
+use Modules\Ad\Support\AdvertisableType;
+
+class UpdateAdRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        /** @var Ad $ad */
+        $ad = $this->route('ad');
+        $statusValues = ['draft', 'pending_review', 'published', 'rejected', 'archived', 'expired'];
+
+        return [
+            'user_id' => ['sometimes', 'required', 'exists:users,id'],
+            'advertisable_type' => ['sometimes', 'required', 'string', Rule::in(AdvertisableType::allowed())],
+            'advertisable_id' => ['sometimes', 'required', 'integer'],
+            'slug' => [
+                'sometimes',
+                'required',
+                'string',
+                'max:255',
+                'alpha_dash',
+                Rule::unique($ad->getTable(), 'slug')->ignore($ad->id),
+            ],
+            'title' => ['sometimes', 'required', 'string', 'max:255'],
+            'subtitle' => ['nullable', 'string', 'max:255'],
+            'description' => ['nullable', 'string'],
+            'status' => ['sometimes', 'required', 'string', Rule::in($statusValues)],
+            'published_at' => ['nullable', 'date'],
+            'expires_at' => ['nullable', 'date', 'after_or_equal:published_at'],
+            'price_amount' => ['nullable', 'integer'],
+            'price_currency' => ['nullable', 'string', 'size:3'],
+            'is_negotiable' => ['boolean'],
+            'is_exchangeable' => ['boolean'],
+            'city_id' => ['nullable', 'exists:cities,id'],
+            'province_id' => ['nullable', 'exists:provinces,id'],
+            'latitude' => ['nullable', 'numeric', 'between:-90,90'],
+            'longitude' => ['nullable', 'numeric', 'between:-180,180'],
+            'contact_channel' => ['nullable', 'array'],
+            'view_count' => ['nullable', 'integer', 'min:0'],
+            'share_count' => ['nullable', 'integer', 'min:0'],
+            'favorite_count' => ['nullable', 'integer', 'min:0'],
+            'featured_until' => ['nullable', 'date'],
+            'priority_score' => ['nullable', 'numeric'],
+            'categories' => ['nullable', 'array'],
+            'categories.*.id' => ['required', 'integer', 'exists:ad_categories,id'],
+            'categories.*.is_primary' => ['nullable', 'boolean'],
+            'categories.*.assigned_by' => ['nullable', 'integer', 'exists:users,id'],
+            'status_note' => ['nullable', 'string'],
+            'status_metadata' => ['nullable', 'array'],
+        ];
+    }
+
+    public function prepareForValidation(): void
+    {
+        $this->merge([
+            'is_negotiable' => $this->toBoolean($this->input('is_negotiable')),
+            'is_exchangeable' => $this->toBoolean($this->input('is_exchangeable')),
+        ]);
+    }
+
+    public function withValidator($validator): void
+    {
+        /** @var Ad $ad */
+        $ad = $this->route('ad');
+
+        $validator->after(function ($validator) use ($ad): void {
+            $type = $this->input('advertisable_type', $ad->advertisable_type);
+            $advertisableId = $this->input('advertisable_id', $ad->advertisable_id);
+
+            if (! AdvertisableType::isAllowed($type)) {
+                return;
+            }
+
+            $table = AdvertisableType::tableFor($type);
+            $exists = DB::table($table)->where('id', $advertisableId)->exists();
+
+            if (! $exists) {
+                $validator->errors()->add('advertisable_id', 'The selected advertisable does not exist.');
+            }
+        });
+    }
+
+    private function toBoolean(mixed $value): ?bool
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        return filter_var($value, FILTER_VALIDATE_BOOL, FILTER_NULL_ON_FAILURE);
+    }
+}

--- a/Modules/Ad/app/Http/Requests/AdAttributeDefinition/StoreAdAttributeDefinitionRequest.php
+++ b/Modules/Ad/app/Http/Requests/AdAttributeDefinition/StoreAdAttributeDefinitionRequest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Modules\Ad\Http\Requests\AdAttributeDefinition;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+use Modules\Ad\Models\AdAttributeDefinition;
+
+class StoreAdAttributeDefinitionRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        $dataTypes = ['string', 'integer', 'decimal', 'boolean', 'enum', 'json'];
+
+        return [
+            'group_id' => ['nullable', 'integer', 'exists:ad_attribute_groups,id'],
+            'key' => [
+                'required',
+                'string',
+                'max:255',
+                Rule::unique((new AdAttributeDefinition())->getTable(), 'key')->where(function ($query) {
+                    return $query->where('group_id', $this->input('group_id'));
+                }),
+            ],
+            'label' => ['required', 'string', 'max:255'],
+            'help_text' => ['nullable', 'string'],
+            'data_type' => ['required', 'string', Rule::in($dataTypes)],
+            'unit' => ['nullable', 'string', 'max:255'],
+            'options' => ['nullable', 'array'],
+            'is_required' => ['boolean'],
+            'is_filterable' => ['boolean'],
+            'is_searchable' => ['boolean'],
+            'validation_rules' => ['nullable', 'string'],
+        ];
+    }
+
+    public function prepareForValidation(): void
+    {
+        $this->merge([
+            'is_required' => $this->toBoolean($this->input('is_required')),
+            'is_filterable' => $this->toBoolean($this->input('is_filterable')),
+            'is_searchable' => $this->toBoolean($this->input('is_searchable')),
+        ]);
+    }
+
+    private function toBoolean(mixed $value): ?bool
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        return filter_var($value, FILTER_VALIDATE_BOOL, FILTER_NULL_ON_FAILURE);
+    }
+}

--- a/Modules/Ad/app/Http/Requests/AdAttributeDefinition/StoreAdAttributeDefinitionRequest.php
+++ b/Modules/Ad/app/Http/Requests/AdAttributeDefinition/StoreAdAttributeDefinitionRequest.php
@@ -48,6 +48,59 @@ class StoreAdAttributeDefinitionRequest extends FormRequest
         ]);
     }
 
+    /**
+     * @return array<string, array<string, mixed>>
+     */
+    public function bodyParameters(): array
+    {
+        return [
+            'group_id' => [
+                'description' => 'Identifier of the attribute group this definition belongs to.',
+                'example' => 2,
+            ],
+            'key' => [
+                'description' => 'Unique machine-friendly key for the attribute.',
+                'example' => 'engine_volume',
+            ],
+            'label' => [
+                'description' => 'Human readable label for the attribute.',
+                'example' => 'Engine volume',
+            ],
+            'help_text' => [
+                'description' => 'Helper text to guide form inputs.',
+                'example' => 'Specify the displacement in liters.',
+            ],
+            'data_type' => [
+                'description' => 'Datatype expected for the attribute value.',
+                'example' => 'decimal',
+            ],
+            'unit' => [
+                'description' => 'Unit displayed next to the value.',
+                'example' => 'L',
+            ],
+            'options' => [
+                'description' => 'Available options or constraints for the attribute.',
+                'example' => ['min' => 1.0, 'max' => 5.0],
+            ],
+            'is_required' => [
+                'description' => 'Whether the attribute must be provided when creating ads.',
+                'example' => true,
+            ],
+            'is_filterable' => [
+                'description' => 'Whether the attribute can be used as a filter in listings.',
+                'example' => true,
+            ],
+            'is_searchable' => [
+                'description' => 'Whether the attribute contributes to search indexes.',
+                'example' => false,
+            ],
+            'validation_rules' => [
+                'description' => 'Laravel validation rules applied to the attribute value.',
+                'example' => 'numeric|min:0.5|max:5',
+            ],
+        ];
+    }
+
     private function toBoolean(mixed $value): ?bool
     {
         if ($value === null) {

--- a/Modules/Ad/app/Http/Requests/AdAttributeDefinition/UpdateAdAttributeDefinitionRequest.php
+++ b/Modules/Ad/app/Http/Requests/AdAttributeDefinition/UpdateAdAttributeDefinitionRequest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Modules\Ad\Http\Requests\AdAttributeDefinition;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+use Modules\Ad\Models\AdAttributeDefinition;
+
+class UpdateAdAttributeDefinitionRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        /** @var AdAttributeDefinition $definition */
+        $definition = $this->route('ad_attribute_definition');
+        $dataTypes = ['string', 'integer', 'decimal', 'boolean', 'enum', 'json'];
+
+        return [
+            'group_id' => ['nullable', 'integer', 'exists:ad_attribute_groups,id'],
+            'key' => [
+                'sometimes',
+                'required',
+                'string',
+                'max:255',
+                Rule::unique($definition->getTable(), 'key')
+                    ->where(function ($query) use ($definition) {
+                        $groupId = $this->input('group_id', $definition->group_id);
+
+                        return $query->where('group_id', $groupId);
+                    })
+                    ->ignore($definition->id),
+            ],
+            'label' => ['sometimes', 'required', 'string', 'max:255'],
+            'help_text' => ['nullable', 'string'],
+            'data_type' => ['sometimes', 'required', 'string', Rule::in($dataTypes)],
+            'unit' => ['nullable', 'string', 'max:255'],
+            'options' => ['nullable', 'array'],
+            'is_required' => ['boolean'],
+            'is_filterable' => ['boolean'],
+            'is_searchable' => ['boolean'],
+            'validation_rules' => ['nullable', 'string'],
+        ];
+    }
+
+    public function prepareForValidation(): void
+    {
+        $this->merge([
+            'is_required' => $this->toBoolean($this->input('is_required')),
+            'is_filterable' => $this->toBoolean($this->input('is_filterable')),
+            'is_searchable' => $this->toBoolean($this->input('is_searchable')),
+        ]);
+    }
+
+    private function toBoolean(mixed $value): ?bool
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        return filter_var($value, FILTER_VALIDATE_BOOL, FILTER_NULL_ON_FAILURE);
+    }
+}

--- a/Modules/Ad/app/Http/Requests/AdAttributeDefinition/UpdateAdAttributeDefinitionRequest.php
+++ b/Modules/Ad/app/Http/Requests/AdAttributeDefinition/UpdateAdAttributeDefinitionRequest.php
@@ -55,6 +55,59 @@ class UpdateAdAttributeDefinitionRequest extends FormRequest
         ]);
     }
 
+    /**
+     * @return array<string, array<string, mixed>>
+     */
+    public function bodyParameters(): array
+    {
+        return [
+            'group_id' => [
+                'description' => 'Identifier of the attribute group this definition belongs to.',
+                'example' => 2,
+            ],
+            'key' => [
+                'description' => 'Unique machine-friendly key for the attribute.',
+                'example' => 'engine_volume',
+            ],
+            'label' => [
+                'description' => 'Human readable label for the attribute.',
+                'example' => 'Engine volume',
+            ],
+            'help_text' => [
+                'description' => 'Helper text to guide form inputs.',
+                'example' => 'Specify the displacement in liters.',
+            ],
+            'data_type' => [
+                'description' => 'Datatype expected for the attribute value.',
+                'example' => 'decimal',
+            ],
+            'unit' => [
+                'description' => 'Unit displayed next to the value.',
+                'example' => 'L',
+            ],
+            'options' => [
+                'description' => 'Available options or constraints for the attribute.',
+                'example' => ['min' => 1.0, 'max' => 5.0],
+            ],
+            'is_required' => [
+                'description' => 'Whether the attribute must be provided when creating ads.',
+                'example' => true,
+            ],
+            'is_filterable' => [
+                'description' => 'Whether the attribute can be used as a filter in listings.',
+                'example' => true,
+            ],
+            'is_searchable' => [
+                'description' => 'Whether the attribute contributes to search indexes.',
+                'example' => false,
+            ],
+            'validation_rules' => [
+                'description' => 'Laravel validation rules applied to the attribute value.',
+                'example' => 'numeric|min:0.5|max:5',
+            ],
+        ];
+    }
+
     private function toBoolean(mixed $value): ?bool
     {
         if ($value === null) {

--- a/Modules/Ad/app/Http/Requests/AdAttributeGroup/StoreAdAttributeGroupRequest.php
+++ b/Modules/Ad/app/Http/Requests/AdAttributeGroup/StoreAdAttributeGroupRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Modules\Ad\Http\Requests\AdAttributeGroup;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+use Modules\Ad\Support\AdvertisableType;
+
+class StoreAdAttributeGroupRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'name' => ['required', 'string', 'max:255'],
+            'advertisable_type' => ['nullable', 'string', Rule::in(AdvertisableType::allowed())],
+            'category_id' => ['nullable', 'integer', 'exists:ad_categories,id'],
+            'display_order' => ['nullable', 'integer', 'min:0'],
+        ];
+    }
+}

--- a/Modules/Ad/app/Http/Requests/AdAttributeGroup/StoreAdAttributeGroupRequest.php
+++ b/Modules/Ad/app/Http/Requests/AdAttributeGroup/StoreAdAttributeGroupRequest.php
@@ -22,4 +22,29 @@ class StoreAdAttributeGroupRequest extends FormRequest
             'display_order' => ['nullable', 'integer', 'min:0'],
         ];
     }
+
+    /**
+     * @return array<string, array<string, mixed>>
+     */
+    public function bodyParameters(): array
+    {
+        return [
+            'name' => [
+                'description' => 'Display name of the attribute group.',
+                'example' => 'Engine specifications',
+            ],
+            'advertisable_type' => [
+                'description' => 'Advertisable model class this group applies to.',
+                'example' => 'Modules\\Ad\\Models\\AdCar',
+            ],
+            'category_id' => [
+                'description' => 'Optional category scope for the group.',
+                'example' => 7,
+            ],
+            'display_order' => [
+                'description' => 'Numeric sorting weight for UI rendering.',
+                'example' => 1,
+            ],
+        ];
+    }
 }

--- a/Modules/Ad/app/Http/Requests/AdAttributeGroup/UpdateAdAttributeGroupRequest.php
+++ b/Modules/Ad/app/Http/Requests/AdAttributeGroup/UpdateAdAttributeGroupRequest.php
@@ -22,4 +22,29 @@ class UpdateAdAttributeGroupRequest extends FormRequest
             'display_order' => ['nullable', 'integer', 'min:0'],
         ];
     }
+
+    /**
+     * @return array<string, array<string, mixed>>
+     */
+    public function bodyParameters(): array
+    {
+        return [
+            'name' => [
+                'description' => 'Display name of the attribute group.',
+                'example' => 'Engine specifications',
+            ],
+            'advertisable_type' => [
+                'description' => 'Advertisable model class this group applies to.',
+                'example' => 'Modules\\Ad\\Models\\AdCar',
+            ],
+            'category_id' => [
+                'description' => 'Optional category scope for the group.',
+                'example' => 7,
+            ],
+            'display_order' => [
+                'description' => 'Numeric sorting weight for UI rendering.',
+                'example' => 1,
+            ],
+        ];
+    }
 }

--- a/Modules/Ad/app/Http/Requests/AdAttributeGroup/UpdateAdAttributeGroupRequest.php
+++ b/Modules/Ad/app/Http/Requests/AdAttributeGroup/UpdateAdAttributeGroupRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Modules\Ad\Http\Requests\AdAttributeGroup;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+use Modules\Ad\Support\AdvertisableType;
+
+class UpdateAdAttributeGroupRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'name' => ['sometimes', 'required', 'string', 'max:255'],
+            'advertisable_type' => ['nullable', 'string', Rule::in(AdvertisableType::allowed())],
+            'category_id' => ['nullable', 'integer', 'exists:ad_categories,id'],
+            'display_order' => ['nullable', 'integer', 'min:0'],
+        ];
+    }
+}

--- a/Modules/Ad/app/Http/Requests/AdAttributeValue/StoreAdAttributeValueRequest.php
+++ b/Modules/Ad/app/Http/Requests/AdAttributeValue/StoreAdAttributeValueRequest.php
@@ -60,6 +60,51 @@ class StoreAdAttributeValueRequest extends FormRequest
         });
     }
 
+    /**
+     * @return array<string, array<string, mixed>>
+     */
+    public function bodyParameters(): array
+    {
+        return [
+            'definition_id' => [
+                'description' => 'Identifier of the attribute definition being populated.',
+                'example' => 4,
+            ],
+            'advertisable_type' => [
+                'description' => 'Fully qualified class name of the advertisable subtype.',
+                'example' => 'Modules\\Ad\\Models\\AdCar',
+            ],
+            'advertisable_id' => [
+                'description' => 'Identifier of the advertisable record.',
+                'example' => 15,
+            ],
+            'value_string' => [
+                'description' => 'String value when the definition expects textual data.',
+                'example' => 'Automatic',
+            ],
+            'value_integer' => [
+                'description' => 'Integer value when the definition expects whole numbers.',
+                'example' => 5,
+            ],
+            'value_decimal' => [
+                'description' => 'Decimal value when the definition expects numeric data.',
+                'example' => 1.6,
+            ],
+            'value_boolean' => [
+                'description' => 'Boolean value when the definition expects true or false.',
+                'example' => true,
+            ],
+            'value_json' => [
+                'description' => 'Structured data payload for JSON definitions.',
+                'example' => ['features' => ['sunroof', 'heated seats']],
+            ],
+            'normalized_value' => [
+                'description' => 'Precomputed normalized representation used for search.',
+                'example' => '1.6',
+            ],
+        ];
+    }
+
     private function validateValueMatchesDefinition($validator, AdAttributeDefinition $definition): void
     {
         $valueFields = [

--- a/Modules/Ad/app/Http/Requests/AdAttributeValue/StoreAdAttributeValueRequest.php
+++ b/Modules/Ad/app/Http/Requests/AdAttributeValue/StoreAdAttributeValueRequest.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace Modules\Ad\Http\Requests\AdAttributeValue;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Validation\Rule;
+use Modules\Ad\Models\AdAttributeDefinition;
+use Modules\Ad\Support\AdvertisableType;
+
+class StoreAdAttributeValueRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'definition_id' => ['required', 'integer', 'exists:ad_attribute_definitions,id'],
+            'advertisable_type' => ['required', 'string', Rule::in(AdvertisableType::allowed())],
+            'advertisable_id' => ['required', 'integer'],
+            'value_string' => ['nullable', 'string'],
+            'value_integer' => ['nullable', 'integer'],
+            'value_decimal' => ['nullable', 'numeric'],
+            'value_boolean' => ['nullable', 'boolean'],
+            'value_json' => ['nullable', 'array'],
+            'normalized_value' => ['nullable', 'string', 'max:255'],
+        ];
+    }
+
+    public function prepareForValidation(): void
+    {
+        $this->merge([
+            'value_boolean' => $this->toBoolean($this->input('value_boolean')),
+        ]);
+    }
+
+    public function withValidator($validator): void
+    {
+        $validator->after(function ($validator): void {
+            $definition = $this->definition();
+
+            if ($definition) {
+                $this->validateValueMatchesDefinition($validator, $definition);
+            }
+
+            $type = $this->input('advertisable_type');
+            $advertisableId = $this->input('advertisable_id');
+
+            if (AdvertisableType::isAllowed($type)) {
+                $table = AdvertisableType::tableFor($type);
+                $exists = DB::table($table)->where('id', $advertisableId)->exists();
+
+                if (! $exists) {
+                    $validator->errors()->add('advertisable_id', 'The selected advertisable does not exist.');
+                }
+            }
+        });
+    }
+
+    private function validateValueMatchesDefinition($validator, AdAttributeDefinition $definition): void
+    {
+        $valueFields = [
+            'value_string',
+            'value_integer',
+            'value_decimal',
+            'value_boolean',
+            'value_json',
+        ];
+
+        $hasValue = false;
+
+        foreach ($valueFields as $field) {
+            if ($this->filled($field)) {
+                $hasValue = true;
+                break;
+            }
+        }
+
+        if (! $hasValue) {
+            $validator->errors()->add('value', 'At least one value field must be provided.');
+
+            return;
+        }
+
+        $expectedField = match ($definition->data_type) {
+            'string' => 'value_string',
+            'integer' => 'value_integer',
+            'decimal' => 'value_decimal',
+            'boolean' => 'value_boolean',
+            'enum' => 'value_string',
+            'json' => 'value_json',
+            default => null,
+        };
+
+        if ($expectedField && ! $this->filled($expectedField)) {
+            $validator->errors()->add($expectedField, 'The provided value does not match the definition type.');
+        }
+    }
+
+    private function definition(): ?AdAttributeDefinition
+    {
+        $definitionId = $this->input('definition_id');
+
+        if (! $definitionId) {
+            return null;
+        }
+
+        return AdAttributeDefinition::find($definitionId);
+    }
+
+    private function toBoolean(mixed $value): ?bool
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        return filter_var($value, FILTER_VALIDATE_BOOL, FILTER_NULL_ON_FAILURE);
+    }
+}

--- a/Modules/Ad/app/Http/Requests/AdAttributeValue/UpdateAdAttributeValueRequest.php
+++ b/Modules/Ad/app/Http/Requests/AdAttributeValue/UpdateAdAttributeValueRequest.php
@@ -1,0 +1,126 @@
+<?php
+
+namespace Modules\Ad\Http\Requests\AdAttributeValue;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Validation\Rule;
+use Modules\Ad\Models\AdAttributeDefinition;
+use Modules\Ad\Models\AdAttributeValue;
+use Modules\Ad\Support\AdvertisableType;
+
+class UpdateAdAttributeValueRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'definition_id' => ['sometimes', 'required', 'integer', 'exists:ad_attribute_definitions,id'],
+            'advertisable_type' => ['sometimes', 'required', 'string', Rule::in(AdvertisableType::allowed())],
+            'advertisable_id' => ['sometimes', 'required', 'integer'],
+            'value_string' => ['nullable', 'string'],
+            'value_integer' => ['nullable', 'integer'],
+            'value_decimal' => ['nullable', 'numeric'],
+            'value_boolean' => ['nullable', 'boolean'],
+            'value_json' => ['nullable', 'array'],
+            'normalized_value' => ['nullable', 'string', 'max:255'],
+        ];
+    }
+
+    public function prepareForValidation(): void
+    {
+        $this->merge([
+            'value_boolean' => $this->toBoolean($this->input('value_boolean')),
+        ]);
+    }
+
+    public function withValidator($validator): void
+    {
+        /** @var AdAttributeValue $value */
+        $value = $this->route('ad_attribute_value');
+
+        $validator->after(function ($validator) use ($value): void {
+            $definition = $this->definition() ?? $value->definition;
+
+            if ($definition) {
+                $this->validateValueMatchesDefinition($validator, $definition);
+            }
+
+            $type = $this->input('advertisable_type', $value->advertisable_type);
+            $advertisableId = $this->input('advertisable_id', $value->advertisable_id);
+
+            if (AdvertisableType::isAllowed($type)) {
+                $table = AdvertisableType::tableFor($type);
+                $exists = DB::table($table)->where('id', $advertisableId)->exists();
+
+                if (! $exists) {
+                    $validator->errors()->add('advertisable_id', 'The selected advertisable does not exist.');
+                }
+            }
+        });
+    }
+
+    private function validateValueMatchesDefinition($validator, AdAttributeDefinition $definition): void
+    {
+        $valueFields = [
+            'value_string',
+            'value_integer',
+            'value_decimal',
+            'value_boolean',
+            'value_json',
+        ];
+
+        $hasValue = false;
+
+        foreach ($valueFields as $field) {
+            if ($this->filled($field)) {
+                $hasValue = true;
+                break;
+            }
+        }
+
+        if (! $hasValue) {
+            $validator->errors()->add('value', 'At least one value field must be provided.');
+
+            return;
+        }
+
+        $expectedField = match ($definition->data_type) {
+            'string' => 'value_string',
+            'integer' => 'value_integer',
+            'decimal' => 'value_decimal',
+            'boolean' => 'value_boolean',
+            'enum' => 'value_string',
+            'json' => 'value_json',
+            default => null,
+        };
+
+        if ($expectedField && ! $this->filled($expectedField)) {
+            $validator->errors()->add($expectedField, 'The provided value does not match the definition type.');
+        }
+    }
+
+    private function definition(): ?AdAttributeDefinition
+    {
+        $definitionId = $this->input('definition_id');
+
+        if (! $definitionId) {
+            return null;
+        }
+
+        return AdAttributeDefinition::find($definitionId);
+    }
+
+    private function toBoolean(mixed $value): ?bool
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        return filter_var($value, FILTER_VALIDATE_BOOL, FILTER_NULL_ON_FAILURE);
+    }
+}

--- a/Modules/Ad/app/Http/Requests/AdAttributeValue/UpdateAdAttributeValueRequest.php
+++ b/Modules/Ad/app/Http/Requests/AdAttributeValue/UpdateAdAttributeValueRequest.php
@@ -64,6 +64,51 @@ class UpdateAdAttributeValueRequest extends FormRequest
         });
     }
 
+    /**
+     * @return array<string, array<string, mixed>>
+     */
+    public function bodyParameters(): array
+    {
+        return [
+            'definition_id' => [
+                'description' => 'Identifier of the attribute definition being populated.',
+                'example' => 4,
+            ],
+            'advertisable_type' => [
+                'description' => 'Fully qualified class name of the advertisable subtype.',
+                'example' => 'Modules\\Ad\\Models\\AdCar',
+            ],
+            'advertisable_id' => [
+                'description' => 'Identifier of the advertisable record.',
+                'example' => 15,
+            ],
+            'value_string' => [
+                'description' => 'String value when the definition expects textual data.',
+                'example' => 'Automatic',
+            ],
+            'value_integer' => [
+                'description' => 'Integer value when the definition expects whole numbers.',
+                'example' => 5,
+            ],
+            'value_decimal' => [
+                'description' => 'Decimal value when the definition expects numeric data.',
+                'example' => 1.6,
+            ],
+            'value_boolean' => [
+                'description' => 'Boolean value when the definition expects true or false.',
+                'example' => true,
+            ],
+            'value_json' => [
+                'description' => 'Structured data payload for JSON definitions.',
+                'example' => ['features' => ['sunroof', 'heated seats']],
+            ],
+            'normalized_value' => [
+                'description' => 'Precomputed normalized representation used for search.',
+                'example' => '1.6',
+            ],
+        ];
+    }
+
     private function validateValueMatchesDefinition($validator, AdAttributeDefinition $definition): void
     {
         $valueFields = [

--- a/Modules/Ad/app/Http/Requests/AdCategory/StoreAdCategoryRequest.php
+++ b/Modules/Ad/app/Http/Requests/AdCategory/StoreAdCategoryRequest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Modules\Ad\Http\Requests\AdCategory;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+use Modules\Ad\Models\AdCategory;
+
+class StoreAdCategoryRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'parent_id' => ['nullable', 'integer', 'exists:ad_categories,id'],
+            'slug' => ['required', 'string', 'max:255', 'alpha_dash', Rule::unique((new AdCategory())->getTable(), 'slug')],
+            'name' => ['required', 'string', 'max:255'],
+            'name_localized' => ['nullable', 'array'],
+            'is_active' => ['boolean'],
+            'sort_order' => ['nullable', 'integer'],
+            'filters_schema' => ['nullable', 'array'],
+        ];
+    }
+
+    public function prepareForValidation(): void
+    {
+        $this->merge([
+            'is_active' => $this->toBoolean($this->input('is_active')),
+        ]);
+    }
+
+    private function toBoolean(mixed $value): ?bool
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        return filter_var($value, FILTER_VALIDATE_BOOL, FILTER_NULL_ON_FAILURE);
+    }
+}

--- a/Modules/Ad/app/Http/Requests/AdCategory/StoreAdCategoryRequest.php
+++ b/Modules/Ad/app/Http/Requests/AdCategory/StoreAdCategoryRequest.php
@@ -33,6 +33,43 @@ class StoreAdCategoryRequest extends FormRequest
         ]);
     }
 
+    /**
+     * @return array<string, array<string, mixed>>
+     */
+    public function bodyParameters(): array
+    {
+        return [
+            'parent_id' => [
+                'description' => 'Identifier of the parent category.',
+                'example' => 1,
+            ],
+            'slug' => [
+                'description' => 'Unique slug for the category.',
+                'example' => 'vehicles',
+            ],
+            'name' => [
+                'description' => 'Display name of the category.',
+                'example' => 'Vehicles',
+            ],
+            'name_localized' => [
+                'description' => 'Localized translations for the category name.',
+                'example' => ['fa' => 'وسایل نقلیه'],
+            ],
+            'is_active' => [
+                'description' => 'Toggle to activate or deactivate the category.',
+                'example' => true,
+            ],
+            'sort_order' => [
+                'description' => 'Custom ordering index.',
+                'example' => 5,
+            ],
+            'filters_schema' => [
+                'description' => 'JSON schema describing available filters.',
+                'example' => ['color' => ['type' => 'enum', 'options' => ['red', 'blue']]],
+            ],
+        ];
+    }
+
     private function toBoolean(mixed $value): ?bool
     {
         if ($value === null) {

--- a/Modules/Ad/app/Http/Requests/AdCategory/UpdateAdCategoryRequest.php
+++ b/Modules/Ad/app/Http/Requests/AdCategory/UpdateAdCategoryRequest.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Modules\Ad\Http\Requests\AdCategory;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+use Modules\Ad\Models\AdCategory;
+use Modules\Ad\Models\AdCategoryClosure;
+
+class UpdateAdCategoryRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        /** @var AdCategory $category */
+        $category = $this->route('ad_category');
+
+        return [
+            'parent_id' => ['nullable', 'integer', 'exists:ad_categories,id'],
+            'slug' => [
+                'sometimes',
+                'required',
+                'string',
+                'max:255',
+                'alpha_dash',
+                Rule::unique($category->getTable(), 'slug')->ignore($category->id),
+            ],
+            'name' => ['sometimes', 'required', 'string', 'max:255'],
+            'name_localized' => ['nullable', 'array'],
+            'is_active' => ['boolean'],
+            'sort_order' => ['nullable', 'integer'],
+            'filters_schema' => ['nullable', 'array'],
+        ];
+    }
+
+    public function prepareForValidation(): void
+    {
+        $this->merge([
+            'is_active' => $this->toBoolean($this->input('is_active')),
+        ]);
+    }
+
+    public function withValidator($validator): void
+    {
+        /** @var AdCategory $category */
+        $category = $this->route('ad_category');
+
+        $validator->after(function ($validator) use ($category): void {
+            $parentId = $this->input('parent_id');
+
+            if (! $parentId) {
+                return;
+            }
+
+            if ((int) $parentId === (int) $category->id) {
+                $validator->errors()->add('parent_id', 'A category cannot be its own parent.');
+
+                return;
+            }
+
+            $isDescendant = AdCategoryClosure::query()
+                ->where('ancestor_id', $category->id)
+                ->where('descendant_id', $parentId)
+                ->exists();
+
+            if ($isDescendant) {
+                $validator->errors()->add('parent_id', 'A category cannot be assigned to one of its descendants.');
+            }
+        });
+    }
+
+    private function toBoolean(mixed $value): ?bool
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        return filter_var($value, FILTER_VALIDATE_BOOL, FILTER_NULL_ON_FAILURE);
+    }
+}

--- a/Modules/Ad/app/Http/Requests/AdCategory/UpdateAdCategoryRequest.php
+++ b/Modules/Ad/app/Http/Requests/AdCategory/UpdateAdCategoryRequest.php
@@ -73,6 +73,43 @@ class UpdateAdCategoryRequest extends FormRequest
         });
     }
 
+    /**
+     * @return array<string, array<string, mixed>>
+     */
+    public function bodyParameters(): array
+    {
+        return [
+            'parent_id' => [
+                'description' => 'Identifier of the parent category.',
+                'example' => 1,
+            ],
+            'slug' => [
+                'description' => 'Unique slug for the category.',
+                'example' => 'vehicles',
+            ],
+            'name' => [
+                'description' => 'Display name of the category.',
+                'example' => 'Vehicles',
+            ],
+            'name_localized' => [
+                'description' => 'Localized translations for the category name.',
+                'example' => ['fa' => 'وسایل نقلیه'],
+            ],
+            'is_active' => [
+                'description' => 'Toggle to activate or deactivate the category.',
+                'example' => true,
+            ],
+            'sort_order' => [
+                'description' => 'Custom ordering index.',
+                'example' => 5,
+            ],
+            'filters_schema' => [
+                'description' => 'JSON schema describing available filters.',
+                'example' => ['color' => ['type' => 'enum', 'options' => ['red', 'blue']]],
+            ],
+        ];
+    }
+
     private function toBoolean(mixed $value): ?bool
     {
         if ($value === null) {

--- a/Modules/Ad/app/Http/Resources/AdAttributeDefinitionResource.php
+++ b/Modules/Ad/app/Http/Resources/AdAttributeDefinitionResource.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Modules\Ad\Http\Resources;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/** @mixin \Modules\Ad\Models\AdAttributeDefinition */
+class AdAttributeDefinitionResource extends JsonResource
+{
+    public function toArray($request): array
+    {
+        return [
+            'id' => $this->id,
+            'group_id' => $this->group_id,
+            'key' => $this->key,
+            'label' => $this->label,
+            'help_text' => $this->help_text,
+            'data_type' => $this->data_type,
+            'unit' => $this->unit,
+            'options' => $this->options,
+            'is_required' => $this->is_required,
+            'is_filterable' => $this->is_filterable,
+            'is_searchable' => $this->is_searchable,
+            'validation_rules' => $this->validation_rules,
+            'created_at' => $this->created_at?->toISOString(),
+            'updated_at' => $this->updated_at?->toISOString(),
+        ];
+    }
+}

--- a/Modules/Ad/app/Http/Resources/AdAttributeGroupResource.php
+++ b/Modules/Ad/app/Http/Resources/AdAttributeGroupResource.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Modules\Ad\Http\Resources;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/** @mixin \Modules\Ad\Models\AdAttributeGroup */
+class AdAttributeGroupResource extends JsonResource
+{
+    public function toArray($request): array
+    {
+        return [
+            'id' => $this->id,
+            'name' => $this->name,
+            'advertisable_type' => $this->advertisable_type,
+            'category_id' => $this->category_id,
+            'display_order' => $this->display_order,
+            'created_at' => $this->created_at?->toISOString(),
+            'updated_at' => $this->updated_at?->toISOString(),
+        ];
+    }
+}

--- a/Modules/Ad/app/Http/Resources/AdAttributeValueResource.php
+++ b/Modules/Ad/app/Http/Resources/AdAttributeValueResource.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Modules\Ad\Http\Resources;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/** @mixin \Modules\Ad\Models\AdAttributeValue */
+class AdAttributeValueResource extends JsonResource
+{
+    public function toArray($request): array
+    {
+        return [
+            'id' => $this->id,
+            'definition_id' => $this->definition_id,
+            'advertisable_type' => $this->advertisable_type,
+            'advertisable_id' => $this->advertisable_id,
+            'value_string' => $this->value_string,
+            'value_integer' => $this->value_integer,
+            'value_decimal' => $this->value_decimal,
+            'value_boolean' => $this->value_boolean,
+            'value_json' => $this->value_json,
+            'normalized_value' => $this->normalized_value,
+            'definition' => AdAttributeDefinitionResource::make($this->whenLoaded('definition')),
+            'created_at' => $this->created_at?->toISOString(),
+            'updated_at' => $this->updated_at?->toISOString(),
+        ];
+    }
+}

--- a/Modules/Ad/app/Http/Resources/AdCategoryResource.php
+++ b/Modules/Ad/app/Http/Resources/AdCategoryResource.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Modules\Ad\Http\Resources;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/** @mixin \Modules\Ad\Models\AdCategory */
+class AdCategoryResource extends JsonResource
+{
+    public function toArray($request): array
+    {
+        return [
+            'id' => $this->id,
+            'parent_id' => $this->parent_id,
+            'depth' => $this->depth,
+            'path' => $this->path,
+            'slug' => $this->slug,
+            'name' => $this->name,
+            'name_localized' => $this->name_localized,
+            'is_active' => $this->is_active,
+            'sort_order' => $this->sort_order,
+            'filters_schema' => $this->filters_schema,
+            'created_at' => $this->created_at?->toISOString(),
+            'updated_at' => $this->updated_at?->toISOString(),
+        ];
+    }
+}

--- a/Modules/Ad/app/Http/Resources/AdResource.php
+++ b/Modules/Ad/app/Http/Resources/AdResource.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Modules\Ad\Http\Resources;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/** @mixin \Modules\Ad\Models\Ad */
+class AdResource extends JsonResource
+{
+    public function toArray($request): array
+    {
+        return [
+            'id' => $this->id,
+            'user_id' => $this->user_id,
+            'advertisable_type' => $this->advertisable_type,
+            'advertisable_id' => $this->advertisable_id,
+            'slug' => $this->slug,
+            'title' => $this->title,
+            'subtitle' => $this->subtitle,
+            'description' => $this->description,
+            'status' => $this->status,
+            'published_at' => $this->published_at?->toISOString(),
+            'expires_at' => $this->expires_at?->toISOString(),
+            'price_amount' => $this->price_amount,
+            'price_currency' => $this->price_currency,
+            'is_negotiable' => $this->is_negotiable,
+            'is_exchangeable' => $this->is_exchangeable,
+            'city_id' => $this->city_id,
+            'province_id' => $this->province_id,
+            'latitude' => $this->latitude,
+            'longitude' => $this->longitude,
+            'contact_channel' => $this->contact_channel,
+            'view_count' => $this->view_count,
+            'share_count' => $this->share_count,
+            'favorite_count' => $this->favorite_count,
+            'featured_until' => $this->featured_until?->toISOString(),
+            'priority_score' => $this->priority_score,
+            'categories' => $this->whenLoaded('categories', function () {
+                return $this->categories->map(function ($category) {
+                    return [
+                        'id' => $category->id,
+                        'name' => $category->name,
+                        'slug' => $category->slug,
+                        'depth' => $category->depth,
+                        'path' => $category->path,
+                        'is_active' => $category->is_active,
+                        'pivot' => [
+                            'is_primary' => (bool) $category->pivot->is_primary,
+                            'assigned_by' => $category->pivot->assigned_by,
+                        ],
+                    ];
+                });
+            }),
+            'advertisable' => $this->whenLoaded('advertisable', function () {
+                return $this->advertisable?->toArray();
+            }),
+            'created_at' => $this->created_at?->toISOString(),
+            'updated_at' => $this->updated_at?->toISOString(),
+            'deleted_at' => $this->deleted_at?->toISOString(),
+        ];
+    }
+}

--- a/Modules/Ad/app/Models/Ad.php
+++ b/Modules/Ad/app/Models/Ad.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace Modules\Ad\Models;
+
+use App\Models\City;
+use App\Models\Province;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class Ad extends Model
+{
+    use HasFactory;
+    use SoftDeletes;
+
+    protected $fillable = [
+        'user_id',
+        'advertisable_type',
+        'advertisable_id',
+        'slug',
+        'title',
+        'subtitle',
+        'description',
+        'status',
+        'published_at',
+        'expires_at',
+        'price_amount',
+        'price_currency',
+        'is_negotiable',
+        'is_exchangeable',
+        'city_id',
+        'province_id',
+        'latitude',
+        'longitude',
+        'contact_channel',
+        'view_count',
+        'share_count',
+        'favorite_count',
+        'featured_until',
+        'priority_score',
+    ];
+
+    protected $casts = [
+        'published_at' => 'datetime',
+        'expires_at' => 'datetime',
+        'featured_until' => 'datetime',
+        'contact_channel' => 'array',
+        'is_negotiable' => 'boolean',
+        'is_exchangeable' => 'boolean',
+    ];
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function city(): BelongsTo
+    {
+        return $this->belongsTo(City::class);
+    }
+
+    public function province(): BelongsTo
+    {
+        return $this->belongsTo(Province::class);
+    }
+
+    public function advertisable(): MorphTo
+    {
+        return $this->morphTo();
+    }
+
+    public function categories(): BelongsToMany
+    {
+        return $this->belongsToMany(AdCategory::class, 'ad_category_ad')
+            ->using(AdCategoryAssignment::class)
+            ->withPivot(['is_primary', 'assigned_by'])
+            ->withTimestamps();
+    }
+
+    public function statusHistories(): HasMany
+    {
+        return $this->hasMany(AdStatusHistory::class);
+    }
+
+    public function slugHistories(): HasMany
+    {
+        return $this->hasMany(AdSlugHistory::class);
+    }
+
+    public function favorites(): HasMany
+    {
+        return $this->hasMany(AdFavorite::class);
+    }
+
+    public function reports(): HasMany
+    {
+        return $this->hasMany(AdReport::class);
+    }
+}

--- a/Modules/Ad/app/Models/AdAttributeDefinition.php
+++ b/Modules/Ad/app/Models/AdAttributeDefinition.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Modules\Ad\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class AdAttributeDefinition extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'group_id',
+        'key',
+        'label',
+        'help_text',
+        'data_type',
+        'unit',
+        'options',
+        'is_required',
+        'is_filterable',
+        'is_searchable',
+        'validation_rules',
+    ];
+
+    protected $casts = [
+        'options' => 'array',
+        'is_required' => 'boolean',
+        'is_filterable' => 'boolean',
+        'is_searchable' => 'boolean',
+    ];
+
+    public function group(): BelongsTo
+    {
+        return $this->belongsTo(AdAttributeGroup::class, 'group_id');
+    }
+
+    public function values(): HasMany
+    {
+        return $this->hasMany(AdAttributeValue::class, 'definition_id');
+    }
+}

--- a/Modules/Ad/app/Models/AdAttributeGroup.php
+++ b/Modules/Ad/app/Models/AdAttributeGroup.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Modules\Ad\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class AdAttributeGroup extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'name',
+        'advertisable_type',
+        'category_id',
+        'display_order',
+    ];
+
+    public function category(): BelongsTo
+    {
+        return $this->belongsTo(AdCategory::class, 'category_id');
+    }
+
+    public function definitions(): HasMany
+    {
+        return $this->hasMany(AdAttributeDefinition::class, 'group_id');
+    }
+}

--- a/Modules/Ad/app/Models/AdAttributeValue.php
+++ b/Modules/Ad/app/Models/AdAttributeValue.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Modules\Ad\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
+
+class AdAttributeValue extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'definition_id',
+        'advertisable_type',
+        'advertisable_id',
+        'value_string',
+        'value_integer',
+        'value_decimal',
+        'value_boolean',
+        'value_json',
+        'normalized_value',
+    ];
+
+    protected $casts = [
+        'value_decimal' => 'decimal:4',
+        'value_boolean' => 'boolean',
+        'value_json' => 'array',
+    ];
+
+    public function definition(): BelongsTo
+    {
+        return $this->belongsTo(AdAttributeDefinition::class, 'definition_id');
+    }
+
+    public function advertisable(): MorphTo
+    {
+        return $this->morphTo();
+    }
+}

--- a/Modules/Ad/app/Models/AdCar.php
+++ b/Modules/Ad/app/Models/AdCar.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Modules\Ad\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\MorphOne;
+
+class AdCar extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'slug',
+        'brand_id',
+        'model_id',
+        'year',
+        'mileage',
+        'fuel_type',
+        'transmission',
+        'body_style',
+        'color',
+        'condition',
+        'ownership_count',
+        'vin',
+        'registration_expiry',
+        'insurance_expiry',
+    ];
+
+    protected $casts = [
+        'registration_expiry' => 'date',
+        'insurance_expiry' => 'date',
+    ];
+
+    public function ad(): MorphOne
+    {
+        return $this->morphOne(Ad::class, 'advertisable');
+    }
+}

--- a/Modules/Ad/app/Models/AdCategory.php
+++ b/Modules/Ad/app/Models/AdCategory.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Modules\Ad\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class AdCategory extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'parent_id',
+        'depth',
+        'path',
+        'slug',
+        'name',
+        'name_localized',
+        'is_active',
+        'sort_order',
+        'filters_schema',
+    ];
+
+    protected $casts = [
+        'name_localized' => 'array',
+        'filters_schema' => 'array',
+        'is_active' => 'boolean',
+    ];
+
+    public function parent(): BelongsTo
+    {
+        return $this->belongsTo(self::class, 'parent_id');
+    }
+
+    public function children(): HasMany
+    {
+        return $this->hasMany(self::class, 'parent_id');
+    }
+
+    public function ads(): BelongsToMany
+    {
+        return $this->belongsToMany(Ad::class, 'ad_category_ad')
+            ->using(AdCategoryAssignment::class)
+            ->withPivot(['is_primary', 'assigned_by'])
+            ->withTimestamps();
+    }
+
+    public function attributeGroups(): HasMany
+    {
+        return $this->hasMany(AdAttributeGroup::class, 'category_id');
+    }
+
+    public function ancestors(): BelongsToMany
+    {
+        return $this->belongsToMany(
+            self::class,
+            'ad_category_closure',
+            'descendant_id',
+            'ancestor_id'
+        )->withPivot('depth');
+    }
+
+    public function descendants(): BelongsToMany
+    {
+        return $this->belongsToMany(
+            self::class,
+            'ad_category_closure',
+            'ancestor_id',
+            'descendant_id'
+        )->withPivot('depth');
+    }
+}

--- a/Modules/Ad/app/Models/AdCategoryAssignment.php
+++ b/Modules/Ad/app/Models/AdCategoryAssignment.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Modules\Ad\Models;
+
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\Pivot;
+
+class AdCategoryAssignment extends Pivot
+{
+    protected $table = 'ad_category_ad';
+
+    protected $fillable = [
+        'ad_id',
+        'category_id',
+        'is_primary',
+        'assigned_by',
+    ];
+
+    protected $casts = [
+        'is_primary' => 'boolean',
+    ];
+
+    public function ad(): BelongsTo
+    {
+        return $this->belongsTo(Ad::class);
+    }
+
+    public function category(): BelongsTo
+    {
+        return $this->belongsTo(AdCategory::class, 'category_id');
+    }
+}

--- a/Modules/Ad/app/Models/AdCategoryClosure.php
+++ b/Modules/Ad/app/Models/AdCategoryClosure.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Modules\Ad\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class AdCategoryClosure extends Model
+{
+    public $timestamps = false;
+
+    protected $table = 'ad_category_closure';
+
+    protected $fillable = [
+        'ancestor_id',
+        'descendant_id',
+        'depth',
+    ];
+
+    public function ancestor(): BelongsTo
+    {
+        return $this->belongsTo(AdCategory::class, 'ancestor_id');
+    }
+
+    public function descendant(): BelongsTo
+    {
+        return $this->belongsTo(AdCategory::class, 'descendant_id');
+    }
+}

--- a/Modules/Ad/app/Models/AdFavorite.php
+++ b/Modules/Ad/app/Models/AdFavorite.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Modules\Ad\Models;
+
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class AdFavorite extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'ad_id',
+        'user_id',
+    ];
+
+    public function ad(): BelongsTo
+    {
+        return $this->belongsTo(Ad::class);
+    }
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/Modules/Ad/app/Models/AdJob.php
+++ b/Modules/Ad/app/Models/AdJob.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Modules\Ad\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\MorphOne;
+
+class AdJob extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'slug',
+        'company_name',
+        'position_title',
+        'industry',
+        'employment_type',
+        'experience_level',
+        'education_level',
+        'salary_min',
+        'salary_max',
+        'currency',
+        'salary_type',
+        'work_schedule',
+        'remote_level',
+        'benefits_json',
+    ];
+
+    protected $casts = [
+        'benefits_json' => 'array',
+    ];
+
+    public function ad(): MorphOne
+    {
+        return $this->morphOne(Ad::class, 'advertisable');
+    }
+}

--- a/Modules/Ad/app/Models/AdRealEstate.php
+++ b/Modules/Ad/app/Models/AdRealEstate.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Modules\Ad\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\MorphOne;
+
+class AdRealEstate extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'slug',
+        'property_type',
+        'usage_type',
+        'area_m2',
+        'land_area_m2',
+        'bedrooms',
+        'bathrooms',
+        'parking_spaces',
+        'floor_number',
+        'total_floors',
+        'year_built',
+        'document_type',
+        'has_elevator',
+        'has_storage',
+        'utilities_json',
+    ];
+
+    protected $casts = [
+        'area_m2' => 'decimal:2',
+        'land_area_m2' => 'decimal:2',
+        'has_elevator' => 'boolean',
+        'has_storage' => 'boolean',
+        'utilities_json' => 'array',
+    ];
+
+    public function ad(): MorphOne
+    {
+        return $this->morphOne(Ad::class, 'advertisable');
+    }
+}

--- a/Modules/Ad/app/Models/AdReport.php
+++ b/Modules/Ad/app/Models/AdReport.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Modules\Ad\Models;
+
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class AdReport extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'ad_id',
+        'reported_by',
+        'reason_code',
+        'description',
+        'status',
+        'handled_by',
+        'handled_at',
+        'resolution_notes',
+        'metadata',
+    ];
+
+    protected $casts = [
+        'handled_at' => 'datetime',
+        'metadata' => 'array',
+    ];
+
+    public function ad(): BelongsTo
+    {
+        return $this->belongsTo(Ad::class);
+    }
+
+    public function reporter(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'reported_by');
+    }
+
+    public function handler(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'handled_by');
+    }
+}

--- a/Modules/Ad/app/Models/AdSlugHistory.php
+++ b/Modules/Ad/app/Models/AdSlugHistory.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Modules\Ad\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class AdSlugHistory extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'ad_id',
+        'slug',
+        'redirect_to_slug',
+    ];
+
+    public function ad(): BelongsTo
+    {
+        return $this->belongsTo(Ad::class);
+    }
+}

--- a/Modules/Ad/app/Models/AdStatusHistory.php
+++ b/Modules/Ad/app/Models/AdStatusHistory.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Modules\Ad\Models;
+
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class AdStatusHistory extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'ad_id',
+        'from_status',
+        'to_status',
+        'changed_by',
+        'notes',
+        'metadata',
+    ];
+
+    protected $casts = [
+        'metadata' => 'array',
+    ];
+
+    public function ad(): BelongsTo
+    {
+        return $this->belongsTo(Ad::class);
+    }
+
+    public function moderator(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'changed_by');
+    }
+}

--- a/Modules/Ad/app/Providers/AdServiceProvider.php
+++ b/Modules/Ad/app/Providers/AdServiceProvider.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Modules\Ad\Providers;
+
+use Illuminate\Support\ServiceProvider;
+
+class AdServiceProvider extends ServiceProvider
+{
+    public function boot(): void
+    {
+        $this->loadRoutesFrom(__DIR__ . '/../../routes/api.php');
+        $this->loadMigrationsFrom(__DIR__ . '/../../database/migrations');
+    }
+}

--- a/Modules/Ad/app/Services/CategoryHierarchyManager.php
+++ b/Modules/Ad/app/Services/CategoryHierarchyManager.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Modules\Ad\Services;
+
+use Illuminate\Support\Collection;
+use Modules\Ad\Models\AdCategory;
+use Modules\Ad\Models\AdCategoryClosure;
+
+class CategoryHierarchyManager
+{
+    /**
+     * Apply hierarchy metadata and closure records for a newly created category.
+     */
+    public function handleCreated(AdCategory $category): void
+    {
+        $category->refresh();
+        $parent = $category->parent()->first();
+        $this->applyRecursively($category, $parent);
+    }
+
+    /**
+     * Recalculate hierarchy metadata for the provided category and its descendants.
+     */
+    public function rebuildSubtree(AdCategory $category): void
+    {
+        $category->refresh();
+        $parent = $category->parent()->first();
+        $this->applyRecursively($category, $parent);
+    }
+
+    private function applyRecursively(AdCategory $category, ?AdCategory $parent): void
+    {
+        $depth = $parent ? $parent->depth + 1 : 0;
+        $path = $parent ? trim($parent->path . '>' . $category->slug, '>') : $category->slug;
+
+        $category->forceFill([
+            'depth' => $depth,
+            'path' => $path,
+        ])->save();
+
+        AdCategoryClosure::where('descendant_id', $category->id)->delete();
+
+        $ancestorRows = $parent
+            ? AdCategoryClosure::where('descendant_id', $parent->id)->get(['ancestor_id', 'depth'])
+            : new Collection();
+
+        $records = $ancestorRows->map(function ($row) use ($category) {
+            return [
+                'ancestor_id' => $row->ancestor_id,
+                'descendant_id' => $category->id,
+                'depth' => $row->depth + 1,
+            ];
+        })->all();
+
+        $records[] = [
+            'ancestor_id' => $category->id,
+            'descendant_id' => $category->id,
+            'depth' => 0,
+        ];
+
+        AdCategoryClosure::insert($records);
+
+        $children = $category->children()->orderBy('sort_order')->get();
+
+        foreach ($children as $child) {
+            $this->applyRecursively($child, $category);
+        }
+    }
+}

--- a/Modules/Ad/app/Support/AdvertisableType.php
+++ b/Modules/Ad/app/Support/AdvertisableType.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Modules\Ad\Support;
+
+use Illuminate\Support\Arr;
+use InvalidArgumentException;
+use Modules\Ad\Models\AdCar;
+use Modules\Ad\Models\AdJob;
+use Modules\Ad\Models\AdRealEstate;
+
+class AdvertisableType
+{
+    /**
+     * Map of supported advertisable morph types to their underlying table names.
+     */
+    private const MAP = [
+        AdCar::class => 'ad_cars',
+        AdRealEstate::class => 'ad_real_estates',
+        AdJob::class => 'ad_jobs',
+    ];
+
+    /**
+     * Return the list of supported advertisable morph class names.
+     *
+     * @return array<int, class-string>
+     */
+    public static function allowed(): array
+    {
+        return array_keys(self::MAP);
+    }
+
+    /**
+     * Determine if a given class string is a supported advertisable type.
+     */
+    public static function isAllowed(?string $class): bool
+    {
+        return $class !== null && array_key_exists($class, self::MAP);
+    }
+
+    /**
+     * Resolve the database table name for the given advertisable class name.
+     */
+    public static function tableFor(string $class): string
+    {
+        if (! self::isAllowed($class)) {
+            throw new InvalidArgumentException(sprintf('Unsupported advertisable type [%s].', $class));
+        }
+
+        return Arr::get(self::MAP, $class);
+    }
+}

--- a/Modules/Ad/composer.json
+++ b/Modules/Ad/composer.json
@@ -1,0 +1,28 @@
+{
+    "name": "nwidart/ad",
+    "description": "Ad module",
+    "authors": [
+        {
+            "name": "Wezone",
+            "email": "dev@wezone.test"
+        }
+    ],
+    "extra": {
+        "laravel": {
+            "providers": [],
+            "aliases": {}
+        }
+    },
+    "autoload": {
+        "psr-4": {
+            "Modules\\Ad\\": "app/",
+            "Modules\\Ad\\Database\\Factories\\": "database/factories/",
+            "Modules\\Ad\\Database\\Seeders\\": "database/seeders/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Modules\\Ad\\Tests\\": "tests/"
+        }
+    }
+}

--- a/Modules/Ad/database/migrations/2025_10_05_111958_create_ad_categories_tables.php
+++ b/Modules/Ad/database/migrations/2025_10_05_111958_create_ad_categories_tables.php
@@ -1,0 +1,44 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('ad_categories', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('parent_id')->nullable()->constrained('ad_categories')->nullOnDelete();
+            $table->unsignedTinyInteger('depth')->default(0);
+            $table->string('path', 1024)->nullable();
+            $table->string('slug')->unique();
+            $table->string('name');
+            $table->json('name_localized')->nullable();
+            $table->boolean('is_active')->default(true);
+            $table->unsignedSmallInteger('sort_order')->default(0);
+            $table->json('filters_schema')->nullable();
+            $table->timestamps();
+
+            $table->index(['parent_id', 'sort_order']);
+        });
+
+        Schema::create('ad_category_closure', function (Blueprint $table) {
+            $table->unsignedBigInteger('ancestor_id');
+            $table->unsignedBigInteger('descendant_id');
+            $table->unsignedTinyInteger('depth');
+
+            $table->primary(['ancestor_id', 'descendant_id']);
+
+            $table->foreign('ancestor_id')->references('id')->on('ad_categories')->cascadeOnDelete();
+            $table->foreign('descendant_id')->references('id')->on('ad_categories')->cascadeOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('ad_category_closure');
+        Schema::dropIfExists('ad_categories');
+    }
+};

--- a/Modules/Ad/database/migrations/2025_10_05_112058_create_ads_tables.php
+++ b/Modules/Ad/database/migrations/2025_10_05_112058_create_ads_tables.php
@@ -1,0 +1,134 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('ads', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->morphs('advertisable');
+            $table->string('slug')->unique();
+            $table->string('title');
+            $table->string('subtitle')->nullable();
+            $table->text('description')->nullable();
+            $table->enum('status', [
+                'draft',
+                'pending_review',
+                'published',
+                'rejected',
+                'archived',
+                'expired',
+            ])->default('draft');
+            $table->timestamp('published_at')->nullable();
+            $table->timestamp('expires_at')->nullable();
+            $table->bigInteger('price_amount')->nullable();
+            $table->string('price_currency', 3)->nullable();
+            $table->boolean('is_negotiable')->default(false);
+            $table->boolean('is_exchangeable')->default(false);
+            $table->foreignId('city_id')->nullable()->constrained('cities')->nullOnDelete();
+            $table->foreignId('province_id')->nullable()->constrained('provinces')->nullOnDelete();
+            $table->decimal('latitude', 10, 7)->nullable();
+            $table->decimal('longitude', 10, 7)->nullable();
+            $table->json('contact_channel')->nullable();
+            $table->unsignedBigInteger('view_count')->default(0);
+            $table->unsignedBigInteger('share_count')->default(0);
+            $table->unsignedBigInteger('favorite_count')->default(0);
+            $table->timestamp('featured_until')->nullable();
+            $table->unsignedDecimal('priority_score', 8, 4)->default(0);
+            $table->timestamps();
+            $table->softDeletes();
+
+            $table->index(['status', 'published_at']);
+            $table->index(['city_id', 'province_id']);
+            $table->index(['featured_until', 'priority_score']);
+        });
+
+        Schema::create('ad_category_ad', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('ad_id')->constrained('ads')->cascadeOnDelete();
+            $table->foreignId('category_id')->constrained('ad_categories')->cascadeOnDelete();
+            $table->boolean('is_primary')->default(false);
+            $table->foreignId('assigned_by')->nullable()->constrained('users')->nullOnDelete();
+            $table->timestamps();
+
+            $table->unique(['ad_id', 'category_id']);
+        });
+
+        Schema::create('ad_status_histories', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('ad_id')->constrained('ads')->cascadeOnDelete();
+            $table->enum('from_status', [
+                'draft',
+                'pending_review',
+                'published',
+                'rejected',
+                'archived',
+                'expired',
+            ])->nullable();
+            $table->enum('to_status', [
+                'draft',
+                'pending_review',
+                'published',
+                'rejected',
+                'archived',
+                'expired',
+            ]);
+            $table->foreignId('changed_by')->nullable()->constrained('users')->nullOnDelete();
+            $table->text('notes')->nullable();
+            $table->json('metadata')->nullable();
+            $table->timestamps();
+
+            $table->index(['ad_id', 'created_at']);
+        });
+
+        Schema::create('ad_slug_histories', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('ad_id')->constrained('ads')->cascadeOnDelete();
+            $table->string('slug');
+            $table->string('redirect_to_slug')->nullable();
+            $table->timestamps();
+
+            $table->unique(['ad_id', 'slug']);
+        });
+
+        Schema::create('ad_favorites', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('ad_id')->constrained('ads')->cascadeOnDelete();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->timestamps();
+
+            $table->unique(['ad_id', 'user_id']);
+        });
+
+        Schema::create('ad_reports', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('ad_id')->constrained('ads')->cascadeOnDelete();
+            $table->foreignId('reported_by')->nullable()->constrained('users')->nullOnDelete();
+            $table->string('reason_code');
+            $table->text('description')->nullable();
+            $table->enum('status', ['pending', 'in_review', 'resolved', 'dismissed'])->default('pending');
+            $table->foreignId('handled_by')->nullable()->constrained('users')->nullOnDelete();
+            $table->timestamp('handled_at')->nullable();
+            $table->text('resolution_notes')->nullable();
+            $table->json('metadata')->nullable();
+            $table->timestamps();
+
+            $table->index(['status', 'handled_at']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('ad_reports');
+        Schema::dropIfExists('ad_favorites');
+        Schema::dropIfExists('ad_slug_histories');
+        Schema::dropIfExists('ad_status_histories');
+        Schema::dropIfExists('ad_category_ad');
+        Schema::dropIfExists('ads');
+    }
+};

--- a/Modules/Ad/database/migrations/2025_10_05_112158_create_ad_attribute_tables.php
+++ b/Modules/Ad/database/migrations/2025_10_05_112158_create_ad_attribute_tables.php
@@ -1,0 +1,63 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('ad_attribute_groups', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('advertisable_type')->nullable();
+            $table->foreignId('category_id')->nullable()->constrained('ad_categories')->nullOnDelete();
+            $table->unsignedSmallInteger('display_order')->default(0);
+            $table->timestamps();
+
+            $table->index(['advertisable_type', 'category_id']);
+        });
+
+        Schema::create('ad_attribute_definitions', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('group_id')->nullable()->constrained('ad_attribute_groups')->nullOnDelete();
+            $table->string('key');
+            $table->string('label');
+            $table->text('help_text')->nullable();
+            $table->enum('data_type', ['string', 'integer', 'decimal', 'boolean', 'enum', 'json']);
+            $table->string('unit')->nullable();
+            $table->json('options')->nullable();
+            $table->boolean('is_required')->default(false);
+            $table->boolean('is_filterable')->default(false);
+            $table->boolean('is_searchable')->default(false);
+            $table->string('validation_rules')->nullable();
+            $table->timestamps();
+
+            $table->unique(['key', 'group_id']);
+        });
+
+        Schema::create('ad_attribute_values', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('definition_id')->constrained('ad_attribute_definitions')->cascadeOnDelete();
+            $table->morphs('advertisable');
+            $table->string('value_string')->nullable();
+            $table->bigInteger('value_integer')->nullable();
+            $table->decimal('value_decimal', 15, 4)->nullable();
+            $table->boolean('value_boolean')->nullable();
+            $table->json('value_json')->nullable();
+            $table->string('normalized_value')->nullable();
+            $table->timestamps();
+
+            $table->unique(['definition_id', 'advertisable_type', 'advertisable_id'], 'ad_attribute_values_unique');
+            $table->index(['advertisable_type', 'advertisable_id']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('ad_attribute_values');
+        Schema::dropIfExists('ad_attribute_definitions');
+        Schema::dropIfExists('ad_attribute_groups');
+    }
+};

--- a/Modules/Ad/database/migrations/2025_10_05_112258_create_advertisable_tables.php
+++ b/Modules/Ad/database/migrations/2025_10_05_112258_create_advertisable_tables.php
@@ -1,0 +1,78 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('ad_cars', function (Blueprint $table) {
+            $table->id();
+            $table->string('slug')->unique();
+            $table->foreignId('brand_id')->nullable();
+            $table->foreignId('model_id')->nullable();
+            $table->unsignedSmallInteger('year')->nullable();
+            $table->unsignedInteger('mileage')->nullable();
+            $table->string('fuel_type')->nullable();
+            $table->string('transmission')->nullable();
+            $table->string('body_style')->nullable();
+            $table->string('color')->nullable();
+            $table->string('condition')->nullable();
+            $table->unsignedTinyInteger('ownership_count')->nullable();
+            $table->string('vin', 64)->nullable();
+            $table->date('registration_expiry')->nullable();
+            $table->date('insurance_expiry')->nullable();
+            $table->timestamps();
+
+            $table->index(['brand_id', 'model_id']);
+        });
+
+        Schema::create('ad_real_estates', function (Blueprint $table) {
+            $table->id();
+            $table->string('slug')->unique();
+            $table->string('property_type')->nullable();
+            $table->string('usage_type')->nullable();
+            $table->unsignedDecimal('area_m2', 10, 2)->nullable();
+            $table->unsignedDecimal('land_area_m2', 10, 2)->nullable();
+            $table->unsignedTinyInteger('bedrooms')->nullable();
+            $table->unsignedTinyInteger('bathrooms')->nullable();
+            $table->unsignedTinyInteger('parking_spaces')->nullable();
+            $table->integer('floor_number')->nullable();
+            $table->integer('total_floors')->nullable();
+            $table->unsignedSmallInteger('year_built')->nullable();
+            $table->string('document_type')->nullable();
+            $table->boolean('has_elevator')->default(false);
+            $table->boolean('has_storage')->default(false);
+            $table->json('utilities_json')->nullable();
+            $table->timestamps();
+        });
+
+        Schema::create('ad_jobs', function (Blueprint $table) {
+            $table->id();
+            $table->string('slug')->unique();
+            $table->string('company_name');
+            $table->string('position_title');
+            $table->string('industry')->nullable();
+            $table->string('employment_type')->nullable();
+            $table->string('experience_level')->nullable();
+            $table->string('education_level')->nullable();
+            $table->bigInteger('salary_min')->nullable();
+            $table->bigInteger('salary_max')->nullable();
+            $table->string('currency', 3)->nullable();
+            $table->string('salary_type')->nullable();
+            $table->string('work_schedule')->nullable();
+            $table->string('remote_level')->nullable();
+            $table->json('benefits_json')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('ad_jobs');
+        Schema::dropIfExists('ad_real_estates');
+        Schema::dropIfExists('ad_cars');
+    }
+};

--- a/Modules/Ad/module.json
+++ b/Modules/Ad/module.json
@@ -1,0 +1,11 @@
+{
+    "name": "Ad",
+    "alias": "ad",
+    "description": "Advertisement domain module managing listings and classifieds.",
+    "keywords": ["ads", "classifieds", "listings"],
+    "priority": 0,
+    "providers": [
+        "Modules\\Ad\\Providers\\AdServiceProvider"
+    ],
+    "files": []
+}

--- a/Modules/Ad/routes/api.php
+++ b/Modules/Ad/routes/api.php
@@ -1,0 +1,7 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+
+Route::prefix('ads')->middleware(['api'])->group(function (): void {
+    // API routes for the Ads module will be registered here.
+});

--- a/Modules/Ad/routes/api.php
+++ b/Modules/Ad/routes/api.php
@@ -8,9 +8,33 @@ use Modules\Ad\Http\Controllers\AdCategoryController;
 use Modules\Ad\Http\Controllers\AdController;
 
 Route::middleware(['api'])->group(function (): void {
-    Route::apiResource('ads', AdController::class);
-    Route::apiResource('ad-categories', AdCategoryController::class);
-    Route::apiResource('ad-attribute-groups', AdAttributeGroupController::class);
-    Route::apiResource('ad-attribute-definitions', AdAttributeDefinitionController::class);
-    Route::apiResource('ad-attribute-values', AdAttributeValueController::class);
+    Route::get('ads', [AdController::class, 'index']);
+    Route::post('ads', [AdController::class, 'store']);
+    Route::get('ads/{ad}', [AdController::class, 'show']);
+    Route::post('ads/{ad}/update', [AdController::class, 'update']);
+    Route::post('ads/{ad}/delete', [AdController::class, 'destroy']);
+
+    Route::get('ad-categories', [AdCategoryController::class, 'index']);
+    Route::post('ad-categories', [AdCategoryController::class, 'store']);
+    Route::get('ad-categories/{ad_category}', [AdCategoryController::class, 'show']);
+    Route::post('ad-categories/{ad_category}/update', [AdCategoryController::class, 'update']);
+    Route::post('ad-categories/{ad_category}/delete', [AdCategoryController::class, 'destroy']);
+
+    Route::get('ad-attribute-groups', [AdAttributeGroupController::class, 'index']);
+    Route::post('ad-attribute-groups', [AdAttributeGroupController::class, 'store']);
+    Route::get('ad-attribute-groups/{ad_attribute_group}', [AdAttributeGroupController::class, 'show']);
+    Route::post('ad-attribute-groups/{ad_attribute_group}/update', [AdAttributeGroupController::class, 'update']);
+    Route::post('ad-attribute-groups/{ad_attribute_group}/delete', [AdAttributeGroupController::class, 'destroy']);
+
+    Route::get('ad-attribute-definitions', [AdAttributeDefinitionController::class, 'index']);
+    Route::post('ad-attribute-definitions', [AdAttributeDefinitionController::class, 'store']);
+    Route::get('ad-attribute-definitions/{ad_attribute_definition}', [AdAttributeDefinitionController::class, 'show']);
+    Route::post('ad-attribute-definitions/{ad_attribute_definition}/update', [AdAttributeDefinitionController::class, 'update']);
+    Route::post('ad-attribute-definitions/{ad_attribute_definition}/delete', [AdAttributeDefinitionController::class, 'destroy']);
+
+    Route::get('ad-attribute-values', [AdAttributeValueController::class, 'index']);
+    Route::post('ad-attribute-values', [AdAttributeValueController::class, 'store']);
+    Route::get('ad-attribute-values/{ad_attribute_value}', [AdAttributeValueController::class, 'show']);
+    Route::post('ad-attribute-values/{ad_attribute_value}/update', [AdAttributeValueController::class, 'update']);
+    Route::post('ad-attribute-values/{ad_attribute_value}/delete', [AdAttributeValueController::class, 'destroy']);
 });

--- a/Modules/Ad/routes/api.php
+++ b/Modules/Ad/routes/api.php
@@ -1,7 +1,16 @@
 <?php
 
 use Illuminate\Support\Facades\Route;
+use Modules\Ad\Http\Controllers\AdAttributeDefinitionController;
+use Modules\Ad\Http\Controllers\AdAttributeGroupController;
+use Modules\Ad\Http\Controllers\AdAttributeValueController;
+use Modules\Ad\Http\Controllers\AdCategoryController;
+use Modules\Ad\Http\Controllers\AdController;
 
-Route::prefix('ads')->middleware(['api'])->group(function (): void {
-    // API routes for the Ads module will be registered here.
+Route::middleware(['api'])->group(function (): void {
+    Route::apiResource('ads', AdController::class);
+    Route::apiResource('ad-categories', AdCategoryController::class);
+    Route::apiResource('ad-attribute-groups', AdAttributeGroupController::class);
+    Route::apiResource('ad-attribute-definitions', AdAttributeDefinitionController::class);
+    Route::apiResource('ad-attribute-values', AdAttributeValueController::class);
 });

--- a/modules_statuses.json
+++ b/modules_statuses.json
@@ -2,5 +2,6 @@
     "Auth": true,
     "Notification": false,
     "Settings": true,
-    "User": true
+    "User": true,
+    "Ad": true
 }

--- a/tests/Feature/Ad/AdApiTest.php
+++ b/tests/Feature/Ad/AdApiTest.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace Tests\Feature\Ad;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Modules\Ad\Models\Ad;
+use Modules\Ad\Models\AdCar;
+use Modules\Ad\Models\AdCategory;
+use Modules\Ad\Services\CategoryHierarchyManager;
+use Tests\TestCase;
+use App\Models\User;
+
+class AdApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_creates_an_ad_with_categories(): void
+    {
+        $user = User::factory()->create();
+        $car = AdCar::create([
+            'slug' => 'peugeot-206',
+        ]);
+
+        $category = AdCategory::create([
+            'slug' => 'sedan',
+            'name' => 'Sedan',
+        ]);
+        app(CategoryHierarchyManager::class)->handleCreated($category);
+        $category->refresh();
+
+        $response = $this->postJson('/api/ads', [
+            'user_id' => $user->id,
+            'advertisable_type' => AdCar::class,
+            'advertisable_id' => $car->id,
+            'slug' => 'peugeot-206-2024',
+            'title' => 'Peugeot 206 2024',
+            'description' => 'Brand new condition.',
+            'status' => 'draft',
+            'price_amount' => 450000000,
+            'price_currency' => 'IRR',
+            'is_negotiable' => true,
+            'contact_channel' => ['phone' => '123456789'],
+            'categories' => [
+                ['id' => $category->id, 'is_primary' => true, 'assigned_by' => $user->id],
+            ],
+        ]);
+
+        $response->assertCreated()
+            ->assertJsonPath('data.slug', 'peugeot-206-2024')
+            ->assertJsonPath('data.categories.0.pivot.is_primary', true);
+
+        $this->assertDatabaseHas('ads', [
+            'slug' => 'peugeot-206-2024',
+            'user_id' => $user->id,
+            'advertisable_type' => AdCar::class,
+        ]);
+
+        $this->assertDatabaseHas('ad_category_ad', [
+            'ad_id' => $response->json('data.id'),
+            'category_id' => $category->id,
+            'is_primary' => true,
+        ]);
+    }
+
+    public function test_it_updates_ad_and_records_status_and_slug_history(): void
+    {
+        $user = User::factory()->create();
+        $car = AdCar::create([
+            'slug' => 'samand',
+        ]);
+
+        $category = AdCategory::create([
+            'slug' => 'hatchback',
+            'name' => 'Hatchback',
+        ]);
+        app(CategoryHierarchyManager::class)->handleCreated($category);
+        $category->refresh();
+
+        $ad = Ad::create([
+            'user_id' => $user->id,
+            'advertisable_type' => AdCar::class,
+            'advertisable_id' => $car->id,
+            'slug' => 'samand-2020',
+            'title' => 'Samand 2020',
+            'status' => 'draft',
+        ]);
+        $ad->categories()->attach($category->id, ['is_primary' => true, 'assigned_by' => $user->id]);
+
+        $response = $this->patchJson("/api/ads/{$ad->id}", [
+            'slug' => 'samand-2020-updated',
+            'status' => 'published',
+            'status_note' => 'Approved by moderator',
+            'status_metadata' => ['moderator' => 'system'],
+        ]);
+
+        $response->assertOk()
+            ->assertJsonPath('data.slug', 'samand-2020-updated');
+
+        $this->assertDatabaseHas('ad_slug_histories', [
+            'ad_id' => $ad->id,
+            'slug' => 'samand-2020',
+            'redirect_to_slug' => 'samand-2020-updated',
+        ]);
+
+        $this->assertDatabaseHas('ad_status_histories', [
+            'ad_id' => $ad->id,
+            'from_status' => 'draft',
+            'to_status' => 'published',
+        ]);
+    }
+}

--- a/tests/Feature/Ad/AdApiTest.php
+++ b/tests/Feature/Ad/AdApiTest.php
@@ -86,7 +86,7 @@ class AdApiTest extends TestCase
         ]);
         $ad->categories()->attach($category->id, ['is_primary' => true, 'assigned_by' => $user->id]);
 
-        $response = $this->patchJson("/api/ads/{$ad->id}", [
+        $response = $this->postJson("/api/ads/{$ad->id}/update", [
             'slug' => 'samand-2020-updated',
             'status' => 'published',
             'status_note' => 'Approved by moderator',

--- a/tests/Feature/Ad/AdCategoryApiTest.php
+++ b/tests/Feature/Ad/AdCategoryApiTest.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Tests\Feature\Ad;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Modules\Ad\Models\AdCategory;
+use Modules\Ad\Services\CategoryHierarchyManager;
+use Tests\TestCase;
+
+class AdCategoryApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_creates_a_category_and_builds_hierarchy(): void
+    {
+        $parent = AdCategory::create([
+            'slug' => 'vehicles',
+            'name' => 'Vehicles',
+        ]);
+        app(CategoryHierarchyManager::class)->handleCreated($parent);
+        $parent->refresh();
+
+        $response = $this->postJson('/api/ad-categories', [
+            'parent_id' => $parent->id,
+            'slug' => 'cars',
+            'name' => 'Cars',
+            'sort_order' => 5,
+        ]);
+
+        $response->assertCreated()
+            ->assertJsonPath('data.slug', 'cars')
+            ->assertJsonPath('data.depth', $parent->depth + 1)
+            ->assertJsonPath('data.path', 'vehicles>cars');
+
+        $this->assertDatabaseHas('ad_category_closure', [
+            'ancestor_id' => $parent->id,
+            'descendant_id' => $response->json('data.id'),
+            'depth' => 1,
+        ]);
+    }
+
+    public function test_it_updates_category_and_recalculates_closure(): void
+    {
+        $root = AdCategory::create([
+            'slug' => 'root',
+            'name' => 'Root',
+        ]);
+        app(CategoryHierarchyManager::class)->handleCreated($root);
+        $root->refresh();
+
+        $alternativeParent = AdCategory::create([
+            'slug' => 'secondary',
+            'name' => 'Secondary',
+        ]);
+        app(CategoryHierarchyManager::class)->handleCreated($alternativeParent);
+        $alternativeParent->refresh();
+
+        $child = AdCategory::create([
+            'parent_id' => $root->id,
+            'slug' => 'child',
+            'name' => 'Child',
+        ]);
+        app(CategoryHierarchyManager::class)->handleCreated($child);
+        $child->refresh();
+
+        $response = $this->patchJson("/api/ad-categories/{$child->id}", [
+            'parent_id' => $alternativeParent->id,
+            'slug' => 'child-updated',
+            'name' => 'Child Updated',
+        ]);
+
+        $response->assertOk()
+            ->assertJsonPath('data.path', 'secondary>child-updated')
+            ->assertJsonPath('data.parent_id', $alternativeParent->id);
+
+        $this->assertDatabaseHas('ad_category_closure', [
+            'ancestor_id' => $alternativeParent->id,
+            'descendant_id' => $child->id,
+            'depth' => 1,
+        ]);
+
+        $this->assertDatabaseMissing('ad_category_closure', [
+            'ancestor_id' => $root->id,
+            'descendant_id' => $child->id,
+            'depth' => 1,
+        ]);
+    }
+}

--- a/tests/Feature/Ad/AdCategoryApiTest.php
+++ b/tests/Feature/Ad/AdCategoryApiTest.php
@@ -63,7 +63,7 @@ class AdCategoryApiTest extends TestCase
         app(CategoryHierarchyManager::class)->handleCreated($child);
         $child->refresh();
 
-        $response = $this->patchJson("/api/ad-categories/{$child->id}", [
+        $response = $this->postJson("/api/ad-categories/{$child->id}/update", [
             'parent_id' => $alternativeParent->id,
             'slug' => 'child-updated',
             'name' => 'Child Updated',


### PR DESCRIPTION
## Summary
- add a dedicated Ads module with service provider wiring and module registration
- create migrations for ad categories, listings, dynamic attributes, and advertisable subtypes
- implement Eloquent models for ads, categories, attributes, lifecycle logs, and favorites/reports

## Testing
- php artisan test *(fails: vendor directory not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e2528642b4832b8d6c763b5250b89b