### PR TITLE
feat: add KPI tracking endpoints

### DIFF
--- a/app/Http/Controllers/Api/Kpi/DeviceMetricsController.php
+++ b/app/Http/Controllers/Api/Kpi/DeviceMetricsController.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace App\Http\Controllers\Api\Kpi;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Kpi\DeviceHeartbeatRequest;
+use App\Http\Requests\Kpi\RegisterDeviceRequest;
+use App\Models\KpiDevice;
+use Carbon\CarbonImmutable;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Arr;
+
+class DeviceMetricsController extends Controller
+{
+    public function register(RegisterDeviceRequest $request): JsonResponse
+    {
+        $payload = $request->validated();
+        $timestamp = CarbonImmutable::now();
+
+        $device = KpiDevice::firstOrNew([
+            'device_uuid' => $payload['device_uuid'],
+        ]);
+
+        $device->fill(Arr::only($payload, [
+            'platform',
+            'app_version',
+            'os_version',
+            'device_model',
+            'device_manufacturer',
+            'locale',
+            'timezone',
+            'push_token',
+            'extra',
+        ]));
+
+        if (!$device->platform) {
+            $device->platform = $payload['platform'] ?? 'unknown';
+        }
+
+        $device->first_seen_at = isset($payload['first_seen_at'])
+            ? CarbonImmutable::parse($payload['first_seen_at'])
+            : ($device->first_seen_at ?? CarbonImmutable::parse($payload['last_seen_at'] ?? $timestamp));
+
+        $device->last_seen_at = isset($payload['last_seen_at'])
+            ? CarbonImmutable::parse($payload['last_seen_at'])
+            : ($device->last_seen_at ?? $timestamp);
+
+        if (isset($payload['last_heartbeat_at'])) {
+            $device->last_heartbeat_at = CarbonImmutable::parse($payload['last_heartbeat_at']);
+        }
+
+        if (!$device->exists) {
+            $device->last_heartbeat_at ??= $device->first_seen_at;
+        }
+
+        $device->is_active = true;
+        $device->save();
+
+        return response()->json([
+            'data' => [
+                'device_uuid' => $device->device_uuid,
+                'created' => $device->wasRecentlyCreated,
+                'first_seen_at' => optional($device->first_seen_at)->toIso8601String(),
+                'last_seen_at' => optional($device->last_seen_at)->toIso8601String(),
+                'last_heartbeat_at' => optional($device->last_heartbeat_at)->toIso8601String(),
+            ],
+        ], $device->wasRecentlyCreated ? 201 : 200);
+    }
+
+    public function heartbeat(DeviceHeartbeatRequest $request): JsonResponse
+    {
+        $payload = $request->validated();
+        $timestamp = CarbonImmutable::now();
+
+        $device = KpiDevice::firstOrNew([
+            'device_uuid' => $payload['device_uuid'],
+        ]);
+
+        $device->fill(Arr::only($payload, [
+            'platform',
+            'app_version',
+            'os_version',
+            'extra',
+        ]));
+
+        if (!$device->platform) {
+            $device->platform = $payload['platform'] ?? $device->platform ?? 'unknown';
+        }
+
+        if (!$device->first_seen_at) {
+            $device->first_seen_at = CarbonImmutable::parse($payload['last_seen_at'] ?? $timestamp);
+        }
+
+        $device->last_seen_at = isset($payload['last_seen_at'])
+            ? CarbonImmutable::parse($payload['last_seen_at'])
+            : $timestamp;
+
+        $device->last_heartbeat_at = isset($payload['last_heartbeat_at'])
+            ? CarbonImmutable::parse($payload['last_heartbeat_at'])
+            : $timestamp;
+
+        $device->is_active = true;
+        $device->save();
+
+        return response()->json([
+            'data' => [
+                'device_uuid' => $device->device_uuid,
+                'last_seen_at' => optional($device->last_seen_at)->toIso8601String(),
+                'last_heartbeat_at' => optional($device->last_heartbeat_at)->toIso8601String(),
+            ],
+        ]);
+    }
+}

--- a/app/Http/Controllers/Api/Kpi/EventController.php
+++ b/app/Http/Controllers/Api/Kpi/EventController.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace App\Http\Controllers\Api\Kpi;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Kpi\StoreEventRequest;
+use App\Models\KpiDevice;
+use App\Models\KpiEvent;
+use App\Models\KpiSession;
+use Carbon\CarbonImmutable;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\DB;
+
+class EventController extends Controller
+{
+    public function store(StoreEventRequest $request): JsonResponse
+    {
+        $payload = $request->validated();
+        $now = CarbonImmutable::now();
+        $userId = $request->user()?->id ?? $payload['user_id'] ?? null;
+
+        $device = KpiDevice::firstOrNew([
+            'device_uuid' => $payload['device_uuid'],
+        ]);
+
+        if (isset($payload['platform'])) {
+            $device->platform = $payload['platform'];
+        } elseif (!$device->platform) {
+            $device->platform = 'unknown';
+        }
+
+        if (!$device->first_seen_at) {
+            $device->first_seen_at = $now;
+        }
+
+        $device->last_seen_at = $device->last_seen_at ?? $now;
+        $device->last_heartbeat_at = $device->last_heartbeat_at ?? $device->last_seen_at;
+        $device->is_active = true;
+        $device->save();
+
+        $session = null;
+        if (!empty($payload['session_uuid'])) {
+            $session = KpiSession::where('session_uuid', $payload['session_uuid'])->first();
+            if ($session && $userId && !$session->user_id) {
+                $session->user_id = $userId;
+                $session->save();
+            }
+        }
+
+        $createdEvents = [];
+        $latestActivity = CarbonImmutable::make($device->last_seen_at) ?? $now;
+
+        DB::transaction(function () use ($payload, $device, $session, $userId, $now, &$createdEvents, &$latestActivity) {
+            foreach ($payload['events'] as $eventPayload) {
+                $occurredAt = isset($eventPayload['occurred_at'])
+                    ? CarbonImmutable::parse($eventPayload['occurred_at'])
+                    : $now;
+
+                $latestActivity = $occurredAt->greaterThan($latestActivity) ? $occurredAt : $latestActivity;
+
+                $data = [
+                    'kpi_device_id' => $device->id,
+                    'kpi_session_id' => $session?->id,
+                    'user_id' => $userId,
+                    'event_key' => $eventPayload['event_key'],
+                    'event_name' => $eventPayload['event_name'] ?? null,
+                    'event_category' => $eventPayload['event_category'] ?? null,
+                    'event_value' => $eventPayload['event_value'] ?? null,
+                    'occurred_at' => $occurredAt,
+                    'metadata' => $eventPayload['metadata'] ?? null,
+                ];
+
+                if (!empty($eventPayload['event_uuid'])) {
+                    $event = KpiEvent::updateOrCreate(
+                        ['event_uuid' => $eventPayload['event_uuid']],
+                        array_merge($data, ['event_uuid' => $eventPayload['event_uuid']])
+                    );
+                } else {
+                    $event = $device->events()->create($data);
+                }
+
+                $createdEvents[] = [
+                    'id' => $event->id,
+                    'event_uuid' => $event->event_uuid,
+                    'event_key' => $event->event_key,
+                    'occurred_at' => $event->occurred_at->toIso8601String(),
+                ];
+            }
+        });
+
+        $device->last_seen_at = $latestActivity;
+        $device->last_heartbeat_at = $latestActivity;
+        $device->save();
+
+        if ($session && $latestActivity->greaterThan(CarbonImmutable::make($session->started_at))) {
+            $session->ended_at = $session->ended_at && $latestActivity->lessThan(CarbonImmutable::make($session->ended_at))
+                ? $session->ended_at
+                : $latestActivity;
+            if ($session->ended_at) {
+                $session->duration_seconds = $session->ended_at->diffInSeconds($session->started_at);
+            }
+            $session->save();
+        }
+
+        return response()->json([
+            'data' => $createdEvents,
+        ], 201);
+    }
+}

--- a/app/Http/Controllers/Api/Kpi/InstallationController.php
+++ b/app/Http/Controllers/Api/Kpi/InstallationController.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace App\Http\Controllers\Api\Kpi;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Kpi\StoreInstallationRequest;
+use App\Models\KpiDevice;
+use Carbon\CarbonImmutable;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Arr;
+
+class InstallationController extends Controller
+{
+    public function store(StoreInstallationRequest $request): JsonResponse
+    {
+        $payload = $request->validated();
+        $installedAt = isset($payload['installed_at'])
+            ? CarbonImmutable::parse($payload['installed_at'])
+            : CarbonImmutable::now();
+
+        $device = $this->syncDeviceFromPayload($payload, $installedAt);
+
+        $isReinstall = array_key_exists('is_reinstall', $payload)
+            ? (bool) $payload['is_reinstall']
+            : $device->installations()->exists();
+
+        $installation = $device->installations()->create([
+            'user_id' => $request->user()?->id ?? $payload['user_id'] ?? null,
+            'installed_at' => $installedAt,
+            'app_version' => $payload['app_version'],
+            'install_source' => $payload['install_source'] ?? null,
+            'campaign' => $payload['campaign'] ?? null,
+            'is_reinstall' => $isReinstall,
+            'metadata' => $payload['metadata'] ?? null,
+        ]);
+
+        return response()->json([
+            'data' => [
+                'id' => $installation->id,
+                'device_uuid' => $device->device_uuid,
+                'installed_at' => $installation->installed_at->toIso8601String(),
+                'is_reinstall' => $installation->is_reinstall,
+            ],
+        ], 201);
+    }
+
+    private function syncDeviceFromPayload(array $payload, CarbonImmutable $timestamp): KpiDevice
+    {
+        $device = KpiDevice::firstOrNew([
+            'device_uuid' => $payload['device_uuid'],
+        ]);
+
+        $device->fill(Arr::only($payload, [
+            'platform',
+            'app_version',
+            'os_version',
+            'device_model',
+            'device_manufacturer',
+            'locale',
+            'timezone',
+            'push_token',
+            'extra',
+        ]));
+
+        if (!$device->platform) {
+            $device->platform = $payload['platform'] ?? 'unknown';
+        }
+
+        $device->first_seen_at = $device->first_seen_at ?? $timestamp;
+        $device->last_seen_at = $timestamp;
+        $device->last_heartbeat_at = $device->last_heartbeat_at ?? $timestamp;
+        $device->is_active = true;
+        $device->save();
+
+        return $device;
+    }
+}

--- a/app/Http/Controllers/Api/Kpi/SessionController.php
+++ b/app/Http/Controllers/Api/Kpi/SessionController.php
@@ -1,0 +1,140 @@
+<?php
+
+namespace App\Http\Controllers\Api\Kpi;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Kpi\StoreSessionRequest;
+use App\Http\Requests\Kpi\UpdateSessionRequest;
+use App\Models\KpiDevice;
+use App\Models\KpiSession;
+use Carbon\CarbonImmutable;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Arr;
+
+class SessionController extends Controller
+{
+    public function store(StoreSessionRequest $request): JsonResponse
+    {
+        $payload = $request->validated();
+        $startedAt = CarbonImmutable::parse($payload['started_at']);
+        $endedAt = isset($payload['ended_at']) ? CarbonImmutable::parse($payload['ended_at']) : null;
+
+        $device = $this->syncDevice($payload, $startedAt, $endedAt);
+        $userId = $request->user()?->id ?? $payload['user_id'] ?? null;
+
+        $duration = $payload['duration_seconds'] ?? ($endedAt ? $endedAt->diffInSeconds($startedAt) : null);
+
+        $session = KpiSession::updateOrCreate(
+            ['session_uuid' => $payload['session_uuid']],
+            [
+                'kpi_device_id' => $device->id,
+                'user_id' => $userId,
+                'started_at' => $startedAt,
+                'ended_at' => $endedAt,
+                'duration_seconds' => $duration,
+                'app_version' => $payload['app_version'],
+                'platform' => $payload['platform'] ?? $device->platform,
+                'os_version' => $payload['os_version'] ?? $device->os_version,
+                'network_type' => $payload['network_type'] ?? null,
+                'city' => $payload['city'] ?? null,
+                'country' => $payload['country'] ?? null,
+                'metadata' => $payload['metadata'] ?? null,
+            ]
+        );
+
+        return response()->json([
+            'data' => [
+                'session_uuid' => $session->session_uuid,
+                'started_at' => $session->started_at->toIso8601String(),
+                'ended_at' => optional($session->ended_at)->toIso8601String(),
+                'duration_seconds' => $session->duration_seconds,
+            ],
+        ], $session->wasRecentlyCreated ? 201 : 200);
+    }
+
+    public function update(UpdateSessionRequest $request, KpiSession $session): JsonResponse
+    {
+        $payload = $request->validated();
+        $existingEndedAt = $session->ended_at ? CarbonImmutable::make($session->ended_at) : null;
+        $endedAt = isset($payload['ended_at'])
+            ? CarbonImmutable::parse($payload['ended_at'])
+            : $existingEndedAt;
+
+        $session->fill(Arr::only($payload, [
+            'app_version',
+            'platform',
+            'os_version',
+            'network_type',
+            'city',
+            'country',
+            'metadata',
+        ]));
+
+        if ($endedAt) {
+            $session->ended_at = $endedAt;
+        }
+
+        if (array_key_exists('duration_seconds', $payload)) {
+            $session->duration_seconds = $payload['duration_seconds'];
+        } elseif ($endedAt) {
+            $session->duration_seconds = $endedAt->diffInSeconds(CarbonImmutable::make($session->started_at));
+        }
+
+        if (isset($payload['user_id'])) {
+            $session->user_id = $payload['user_id'];
+        } elseif ($request->user()) {
+            $session->user_id = $request->user()->id;
+        }
+
+        $session->save();
+
+        $device = $session->device;
+        if ($device) {
+            $device->fill(Arr::only($payload, [
+                'app_version',
+                'platform',
+                'os_version',
+            ]));
+            if ($endedAt) {
+                $device->last_seen_at = $endedAt;
+                $device->last_heartbeat_at = $endedAt;
+            }
+            $device->save();
+        }
+
+        return response()->json([
+            'data' => [
+                'session_uuid' => $session->session_uuid,
+                'ended_at' => optional($session->ended_at)->toIso8601String(),
+                'duration_seconds' => $session->duration_seconds,
+            ],
+        ]);
+    }
+
+    private function syncDevice(array $payload, CarbonImmutable $startedAt, ?CarbonImmutable $endedAt = null): KpiDevice
+    {
+        $device = KpiDevice::firstOrNew([
+            'device_uuid' => $payload['device_uuid'],
+        ]);
+
+        $device->fill(Arr::only($payload, [
+            'platform',
+            'app_version',
+            'os_version',
+        ]));
+
+        if (!$device->platform) {
+            $device->platform = $payload['platform'] ?? 'unknown';
+        }
+
+        $device->first_seen_at = $device->first_seen_at ?? $startedAt;
+        $device->last_seen_at = $endedAt ?? $startedAt;
+        if ($endedAt) {
+            $device->last_heartbeat_at = $endedAt;
+        }
+        $device->is_active = true;
+        $device->save();
+
+        return $device;
+    }
+}

--- a/app/Http/Controllers/Api/Kpi/UninstallationController.php
+++ b/app/Http/Controllers/Api/Kpi/UninstallationController.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Http\Controllers\Api\Kpi;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Kpi\StoreUninstallationRequest;
+use App\Models\KpiDevice;
+use Carbon\CarbonImmutable;
+use Illuminate\Http\JsonResponse;
+
+class UninstallationController extends Controller
+{
+    public function store(StoreUninstallationRequest $request): JsonResponse
+    {
+        $payload = $request->validated();
+        $uninstalledAt = isset($payload['uninstalled_at'])
+            ? CarbonImmutable::parse($payload['uninstalled_at'])
+            : CarbonImmutable::now();
+
+        $device = KpiDevice::firstOrNew([
+            'device_uuid' => $payload['device_uuid'],
+        ]);
+
+        if (isset($payload['platform'])) {
+            $device->platform = $payload['platform'];
+        } elseif (!$device->platform) {
+            $device->platform = 'unknown';
+        }
+
+        if (!$device->first_seen_at) {
+            $device->first_seen_at = $uninstalledAt;
+        }
+
+        $device->last_seen_at = $uninstalledAt;
+        $device->last_heartbeat_at = $device->last_heartbeat_at ?? $uninstalledAt;
+        $device->is_active = false;
+        $device->save();
+
+        $uninstallation = $device->uninstallations()->create([
+            'user_id' => $request->user()?->id ?? $payload['user_id'] ?? null,
+            'uninstalled_at' => $uninstalledAt,
+            'app_version' => $payload['app_version'] ?? null,
+            'reason' => $payload['reason'] ?? null,
+            'report_source' => $payload['report_source'] ?? null,
+            'metadata' => $payload['metadata'] ?? null,
+        ]);
+
+        return response()->json([
+            'data' => [
+                'id' => $uninstallation->id,
+                'device_uuid' => $device->device_uuid,
+                'uninstalled_at' => $uninstallation->uninstalled_at->toIso8601String(),
+            ],
+        ], 201);
+    }
+}

--- a/app/Http/Requests/Kpi/DeviceHeartbeatRequest.php
+++ b/app/Http/Requests/Kpi/DeviceHeartbeatRequest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Http\Requests\Kpi;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class DeviceHeartbeatRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'device_uuid' => ['required', 'uuid'],
+            'last_seen_at' => ['nullable', 'date'],
+            'last_heartbeat_at' => ['nullable', 'date'],
+            'app_version' => ['nullable', 'string', 'max:50'],
+            'platform' => ['nullable', 'string', 'max:50'],
+            'os_version' => ['nullable', 'string', 'max:100'],
+            'extra' => ['nullable', 'array'],
+        ];
+    }
+}

--- a/app/Http/Requests/Kpi/RegisterDeviceRequest.php
+++ b/app/Http/Requests/Kpi/RegisterDeviceRequest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Http\Requests\Kpi;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class RegisterDeviceRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'device_uuid' => ['required', 'uuid'],
+            'platform' => ['required', 'string', 'max:50'],
+            'app_version' => ['required', 'string', 'max:50'],
+            'os_version' => ['nullable', 'string', 'max:100'],
+            'device_model' => ['nullable', 'string', 'max:150'],
+            'device_manufacturer' => ['nullable', 'string', 'max:150'],
+            'locale' => ['nullable', 'string', 'max:10'],
+            'timezone' => ['nullable', 'string', 'max:60'],
+            'push_token' => ['nullable', 'string', 'max:255'],
+            'first_seen_at' => ['nullable', 'date'],
+            'last_seen_at' => ['nullable', 'date'],
+            'last_heartbeat_at' => ['nullable', 'date'],
+            'extra' => ['nullable', 'array'],
+        ];
+    }
+}

--- a/app/Http/Requests/Kpi/StoreEventRequest.php
+++ b/app/Http/Requests/Kpi/StoreEventRequest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Http\Requests\Kpi;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreEventRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'device_uuid' => ['required', 'uuid'],
+            'session_uuid' => ['nullable', 'uuid'],
+            'platform' => ['nullable', 'string', 'max:50'],
+            'user_id' => ['nullable', 'integer', 'exists:users,id'],
+            'events' => ['required', 'array', 'min:1'],
+            'events.*.event_uuid' => ['nullable', 'uuid'],
+            'events.*.event_key' => ['required', 'string', 'max:100'],
+            'events.*.event_name' => ['nullable', 'string', 'max:255'],
+            'events.*.event_category' => ['nullable', 'string', 'max:100'],
+            'events.*.event_value' => ['nullable', 'numeric'],
+            'events.*.occurred_at' => ['nullable', 'date'],
+            'events.*.metadata' => ['nullable', 'array'],
+        ];
+    }
+}

--- a/app/Http/Requests/Kpi/StoreInstallationRequest.php
+++ b/app/Http/Requests/Kpi/StoreInstallationRequest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Http\Requests\Kpi;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreInstallationRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'device_uuid' => ['required', 'uuid'],
+            'installed_at' => ['nullable', 'date'],
+            'app_version' => ['required', 'string', 'max:50'],
+            'platform' => ['required', 'string', 'max:50'],
+            'os_version' => ['nullable', 'string', 'max:100'],
+            'device_model' => ['nullable', 'string', 'max:150'],
+            'device_manufacturer' => ['nullable', 'string', 'max:150'],
+            'locale' => ['nullable', 'string', 'max:10'],
+            'timezone' => ['nullable', 'string', 'max:60'],
+            'push_token' => ['nullable', 'string', 'max:255'],
+            'install_source' => ['nullable', 'string', 'max:100'],
+            'campaign' => ['nullable', 'string', 'max:100'],
+            'is_reinstall' => ['nullable', 'boolean'],
+            'metadata' => ['nullable', 'array'],
+            'extra' => ['nullable', 'array'],
+            'user_id' => ['nullable', 'integer', 'exists:users,id'],
+        ];
+    }
+}

--- a/app/Http/Requests/Kpi/StoreSessionRequest.php
+++ b/app/Http/Requests/Kpi/StoreSessionRequest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Http\Requests\Kpi;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreSessionRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'device_uuid' => ['required', 'uuid'],
+            'session_uuid' => ['required', 'uuid'],
+            'started_at' => ['required', 'date'],
+            'ended_at' => ['nullable', 'date', 'after_or_equal:started_at'],
+            'duration_seconds' => ['nullable', 'integer', 'min:0'],
+            'app_version' => ['required', 'string', 'max:50'],
+            'platform' => ['nullable', 'string', 'max:50'],
+            'os_version' => ['nullable', 'string', 'max:100'],
+            'network_type' => ['nullable', 'string', 'max:50'],
+            'city' => ['nullable', 'string', 'max:150'],
+            'country' => ['nullable', 'string', 'max:150'],
+            'metadata' => ['nullable', 'array'],
+            'user_id' => ['nullable', 'integer', 'exists:users,id'],
+        ];
+    }
+}

--- a/app/Http/Requests/Kpi/StoreUninstallationRequest.php
+++ b/app/Http/Requests/Kpi/StoreUninstallationRequest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Http\Requests\Kpi;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreUninstallationRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'device_uuid' => ['required', 'uuid'],
+            'uninstalled_at' => ['nullable', 'date'],
+            'app_version' => ['nullable', 'string', 'max:50'],
+            'platform' => ['nullable', 'string', 'max:50'],
+            'reason' => ['nullable', 'string', 'max:255'],
+            'report_source' => ['nullable', 'string', 'max:100'],
+            'metadata' => ['nullable', 'array'],
+            'user_id' => ['nullable', 'integer', 'exists:users,id'],
+        ];
+    }
+}

--- a/app/Http/Requests/Kpi/UpdateSessionRequest.php
+++ b/app/Http/Requests/Kpi/UpdateSessionRequest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Http\Requests\Kpi;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateSessionRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'ended_at' => ['nullable', 'date'],
+            'duration_seconds' => ['nullable', 'integer', 'min:0'],
+            'app_version' => ['nullable', 'string', 'max:50'],
+            'platform' => ['nullable', 'string', 'max:50'],
+            'os_version' => ['nullable', 'string', 'max:100'],
+            'network_type' => ['nullable', 'string', 'max:50'],
+            'city' => ['nullable', 'string', 'max:150'],
+            'country' => ['nullable', 'string', 'max:150'],
+            'metadata' => ['nullable', 'array'],
+            'user_id' => ['nullable', 'integer', 'exists:users,id'],
+        ];
+    }
+}

--- a/app/Models/KpiDevice.php
+++ b/app/Models/KpiDevice.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class KpiDevice extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'device_uuid',
+        'platform',
+        'app_version',
+        'os_version',
+        'device_model',
+        'device_manufacturer',
+        'locale',
+        'timezone',
+        'push_token',
+        'first_seen_at',
+        'last_seen_at',
+        'last_heartbeat_at',
+        'is_active',
+        'extra',
+    ];
+
+    protected $casts = [
+        'first_seen_at' => 'datetime',
+        'last_seen_at' => 'datetime',
+        'last_heartbeat_at' => 'datetime',
+        'is_active' => 'boolean',
+        'extra' => 'array',
+    ];
+
+    /**
+     * @return HasMany<KpiInstallation>
+     */
+    public function installations(): HasMany
+    {
+        return $this->hasMany(KpiInstallation::class);
+    }
+
+    /**
+     * @return HasMany<KpiUninstallation>
+     */
+    public function uninstallations(): HasMany
+    {
+        return $this->hasMany(KpiUninstallation::class);
+    }
+
+    /**
+     * @return HasMany<KpiSession>
+     */
+    public function sessions(): HasMany
+    {
+        return $this->hasMany(KpiSession::class);
+    }
+
+    /**
+     * @return HasMany<KpiEvent>
+     */
+    public function events(): HasMany
+    {
+        return $this->hasMany(KpiEvent::class);
+    }
+}

--- a/app/Models/KpiEvent.php
+++ b/app/Models/KpiEvent.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class KpiEvent extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'event_uuid',
+        'kpi_device_id',
+        'kpi_session_id',
+        'user_id',
+        'event_key',
+        'event_name',
+        'event_category',
+        'event_value',
+        'occurred_at',
+        'metadata',
+    ];
+
+    protected $casts = [
+        'event_value' => 'float',
+        'occurred_at' => 'datetime',
+        'metadata' => 'array',
+    ];
+
+    public function device(): BelongsTo
+    {
+        return $this->belongsTo(KpiDevice::class, 'kpi_device_id');
+    }
+
+    public function session(): BelongsTo
+    {
+        return $this->belongsTo(KpiSession::class, 'kpi_session_id');
+    }
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/app/Models/KpiInstallation.php
+++ b/app/Models/KpiInstallation.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class KpiInstallation extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'kpi_device_id',
+        'user_id',
+        'installed_at',
+        'app_version',
+        'install_source',
+        'campaign',
+        'is_reinstall',
+        'metadata',
+    ];
+
+    protected $casts = [
+        'installed_at' => 'datetime',
+        'is_reinstall' => 'boolean',
+        'metadata' => 'array',
+    ];
+
+    public function device(): BelongsTo
+    {
+        return $this->belongsTo(KpiDevice::class, 'kpi_device_id');
+    }
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/app/Models/KpiSession.php
+++ b/app/Models/KpiSession.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class KpiSession extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'session_uuid',
+        'kpi_device_id',
+        'user_id',
+        'started_at',
+        'ended_at',
+        'duration_seconds',
+        'app_version',
+        'platform',
+        'os_version',
+        'network_type',
+        'city',
+        'country',
+        'metadata',
+    ];
+
+    protected $casts = [
+        'started_at' => 'datetime',
+        'ended_at' => 'datetime',
+        'duration_seconds' => 'integer',
+        'metadata' => 'array',
+    ];
+
+    public function getRouteKeyName(): string
+    {
+        return 'session_uuid';
+    }
+
+    public function device(): BelongsTo
+    {
+        return $this->belongsTo(KpiDevice::class, 'kpi_device_id');
+    }
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    /**
+     * @return HasMany<KpiEvent>
+     */
+    public function events(): HasMany
+    {
+        return $this->hasMany(KpiEvent::class, 'kpi_session_id');
+    }
+}

--- a/app/Models/KpiUninstallation.php
+++ b/app/Models/KpiUninstallation.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class KpiUninstallation extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'kpi_device_id',
+        'user_id',
+        'uninstalled_at',
+        'app_version',
+        'reason',
+        'report_source',
+        'metadata',
+    ];
+
+    protected $casts = [
+        'uninstalled_at' => 'datetime',
+        'metadata' => 'array',
+    ];
+
+    public function device(): BelongsTo
+    {
+        return $this->belongsTo(KpiDevice::class, 'kpi_device_id');
+    }
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/database/migrations/2025_10_05_194636_create_kpi_devices_table.php
+++ b/database/migrations/2025_10_05_194636_create_kpi_devices_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('kpi_devices', function (Blueprint $table) {
+            $table->id();
+            $table->uuid('device_uuid')->unique();
+            $table->string('platform')->index();
+            $table->string('app_version')->nullable()->index();
+            $table->string('os_version')->nullable();
+            $table->string('device_model')->nullable();
+            $table->string('device_manufacturer')->nullable();
+            $table->string('locale')->nullable();
+            $table->string('timezone')->nullable();
+            $table->string('push_token')->nullable();
+            $table->timestamp('first_seen_at')->nullable();
+            $table->timestamp('last_seen_at')->nullable()->index();
+            $table->timestamp('last_heartbeat_at')->nullable();
+            $table->boolean('is_active')->default(true)->index();
+            $table->json('extra')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('kpi_devices');
+    }
+};

--- a/database/migrations/2025_10_05_194638_create_kpi_installations_table.php
+++ b/database/migrations/2025_10_05_194638_create_kpi_installations_table.php
@@ -1,0 +1,38 @@
+<?php
+
+use App\Models\User;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('kpi_installations', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('kpi_device_id')->constrained('kpi_devices')->cascadeOnDelete();
+            $table->foreignIdFor(User::class)->nullable()->constrained()->nullOnDelete();
+            $table->timestamp('installed_at')->index();
+            $table->string('app_version')->nullable();
+            $table->string('install_source')->nullable();
+            $table->string('campaign')->nullable();
+            $table->boolean('is_reinstall')->default(false)->index();
+            $table->json('metadata')->nullable();
+            $table->timestamps();
+
+            $table->index(['kpi_device_id', 'installed_at']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('kpi_installations');
+    }
+};

--- a/database/migrations/2025_10_05_194639_create_kpi_uninstallations_table.php
+++ b/database/migrations/2025_10_05_194639_create_kpi_uninstallations_table.php
@@ -1,0 +1,37 @@
+<?php
+
+use App\Models\User;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('kpi_uninstallations', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('kpi_device_id')->constrained('kpi_devices')->cascadeOnDelete();
+            $table->foreignIdFor(User::class)->nullable()->constrained()->nullOnDelete();
+            $table->timestamp('uninstalled_at')->index();
+            $table->string('app_version')->nullable();
+            $table->string('reason')->nullable();
+            $table->string('report_source')->nullable();
+            $table->json('metadata')->nullable();
+            $table->timestamps();
+
+            $table->index(['kpi_device_id', 'uninstalled_at']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('kpi_uninstallations');
+    }
+};

--- a/database/migrations/2025_10_05_194641_create_kpi_sessions_table.php
+++ b/database/migrations/2025_10_05_194641_create_kpi_sessions_table.php
@@ -1,0 +1,43 @@
+<?php
+
+use App\Models\User;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('kpi_sessions', function (Blueprint $table) {
+            $table->id();
+            $table->uuid('session_uuid')->unique();
+            $table->foreignId('kpi_device_id')->constrained('kpi_devices')->cascadeOnDelete();
+            $table->foreignIdFor(User::class)->nullable()->constrained()->nullOnDelete();
+            $table->timestamp('started_at')->index();
+            $table->timestamp('ended_at')->nullable()->index();
+            $table->unsignedInteger('duration_seconds')->nullable();
+            $table->string('app_version')->nullable();
+            $table->string('platform')->nullable();
+            $table->string('os_version')->nullable();
+            $table->string('network_type')->nullable();
+            $table->string('city')->nullable();
+            $table->string('country')->nullable();
+            $table->json('metadata')->nullable();
+            $table->timestamps();
+
+            $table->index(['kpi_device_id', 'started_at']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('kpi_sessions');
+    }
+};

--- a/database/migrations/2025_10_05_194643_create_kpi_events_table.php
+++ b/database/migrations/2025_10_05_194643_create_kpi_events_table.php
@@ -1,0 +1,41 @@
+<?php
+
+use App\Models\User;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('kpi_events', function (Blueprint $table) {
+            $table->id();
+            $table->uuid('event_uuid')->nullable()->unique();
+            $table->foreignId('kpi_device_id')->constrained('kpi_devices')->cascadeOnDelete();
+            $table->foreignId('kpi_session_id')->nullable()->constrained('kpi_sessions')->nullOnDelete();
+            $table->foreignIdFor(User::class)->nullable()->constrained()->nullOnDelete();
+            $table->string('event_key');
+            $table->string('event_name')->nullable();
+            $table->string('event_category')->nullable();
+            $table->double('event_value')->nullable();
+            $table->timestamp('occurred_at')->index();
+            $table->json('metadata')->nullable();
+            $table->timestamps();
+
+            $table->index(['kpi_device_id', 'occurred_at']);
+            $table->index(['event_key', 'occurred_at']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('kpi_events');
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -2,6 +2,11 @@
 
 use App\Http\Controllers\Api\CityController;
 use App\Http\Controllers\Api\CountryController;
+use App\Http\Controllers\Api\Kpi\DeviceMetricsController;
+use App\Http\Controllers\Api\Kpi\EventController;
+use App\Http\Controllers\Api\Kpi\InstallationController;
+use App\Http\Controllers\Api\Kpi\SessionController;
+use App\Http\Controllers\Api\Kpi\UninstallationController;
 use App\Http\Controllers\Api\GeolocationController;
 use App\Http\Controllers\Api\ProvinceController;
 use Illuminate\Support\Facades\Artisan;
@@ -22,6 +27,16 @@ Route::prefix('geography')->middleware("auth:api")->group(function () {
     Route::get('locations/lookup', [GeolocationController::class, 'lookup']);
     Route::get('locations/user-city', [GeolocationController::class, 'resolveUserCity']);
     Route::get('locations/nearby-cities', [GeolocationController::class, 'nearbyCities']);
+});
+
+Route::prefix('kpi')->group(function () {
+    Route::post('devices/register', [DeviceMetricsController::class, 'register']);
+    Route::post('devices/heartbeat', [DeviceMetricsController::class, 'heartbeat']);
+    Route::post('installations', [InstallationController::class, 'store']);
+    Route::post('uninstallations', [UninstallationController::class, 'store']);
+    Route::post('sessions', [SessionController::class, 'store']);
+    Route::patch('sessions/{session:session_uuid}', [SessionController::class, 'update']);
+    Route::post('events', [EventController::class, 'store']);
 });
 
 

--- a/tests/Feature/Api/Kpi/KpiEndpointsTest.php
+++ b/tests/Feature/Api/Kpi/KpiEndpointsTest.php
@@ -1,0 +1,152 @@
+<?php
+
+namespace Tests\Feature\Api\Kpi;
+
+use App\Models\KpiDevice;
+use App\Models\KpiEvent;
+use App\Models\KpiSession;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+class KpiEndpointsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_device_registration_creates_device_record(): void
+    {
+        $deviceUuid = (string) Str::uuid();
+
+        $response = $this->postJson('/api/kpi/devices/register', [
+            'device_uuid' => $deviceUuid,
+            'platform' => 'android',
+            'app_version' => '1.0.0',
+            'os_version' => '14',
+            'device_model' => 'Pixel 8',
+            'device_manufacturer' => 'Google',
+            'locale' => 'en',
+            'timezone' => 'UTC',
+        ]);
+
+        $response->assertCreated();
+
+        $this->assertDatabaseHas('kpi_devices', [
+            'device_uuid' => $deviceUuid,
+            'platform' => 'android',
+            'app_version' => '1.0.0',
+        ]);
+    }
+
+    public function test_installation_endpoint_marks_reinstall_automatically(): void
+    {
+        $deviceUuid = (string) Str::uuid();
+
+        $this->postJson('/api/kpi/installations', [
+            'device_uuid' => $deviceUuid,
+            'installed_at' => now()->toIso8601String(),
+            'app_version' => '1.0.0',
+            'platform' => 'android',
+        ])->assertCreated();
+
+        $this->postJson('/api/kpi/installations', [
+            'device_uuid' => $deviceUuid,
+            'installed_at' => now()->addDay()->toIso8601String(),
+            'app_version' => '1.1.0',
+            'platform' => 'android',
+        ])->assertCreated();
+
+        $this->assertDatabaseHas('kpi_installations', [
+            'kpi_device_id' => KpiDevice::firstWhere('device_uuid', $deviceUuid)?->id,
+            'is_reinstall' => true,
+        ]);
+    }
+
+    public function test_session_store_and_update_flow(): void
+    {
+        $deviceUuid = (string) Str::uuid();
+        $sessionUuid = (string) Str::uuid();
+
+        $storeResponse = $this->postJson('/api/kpi/sessions', [
+            'device_uuid' => $deviceUuid,
+            'session_uuid' => $sessionUuid,
+            'started_at' => now()->subMinutes(5)->toIso8601String(),
+            'ended_at' => now()->subMinutes(1)->toIso8601String(),
+            'app_version' => '2.0.0',
+            'platform' => 'android',
+            'network_type' => 'wifi',
+        ]);
+
+        $storeResponse->assertCreated();
+
+        $updateResponse = $this->patchJson("/api/kpi/sessions/{$sessionUuid}", [
+            'ended_at' => now()->toIso8601String(),
+            'network_type' => '5g',
+        ]);
+
+        $updateResponse->assertOk();
+
+        $session = KpiSession::firstWhere('session_uuid', $sessionUuid);
+        $this->assertNotNull($session);
+        $this->assertSame('5g', $session->network_type);
+        $this->assertNotNull($session->duration_seconds);
+    }
+
+    public function test_event_endpoint_persists_multiple_events(): void
+    {
+        $deviceUuid = (string) Str::uuid();
+        $sessionUuid = (string) Str::uuid();
+
+        $this->postJson('/api/kpi/sessions', [
+            'device_uuid' => $deviceUuid,
+            'session_uuid' => $sessionUuid,
+            'started_at' => now()->subMinutes(10)->toIso8601String(),
+            'app_version' => '3.0.0',
+            'platform' => 'android',
+        ])->assertCreated();
+
+        $response = $this->postJson('/api/kpi/events', [
+            'device_uuid' => $deviceUuid,
+            'session_uuid' => $sessionUuid,
+            'events' => [
+                [
+                    'event_uuid' => (string) Str::uuid(),
+                    'event_key' => 'ad_view',
+                    'occurred_at' => now()->subMinutes(2)->toIso8601String(),
+                ],
+                [
+                    'event_key' => 'ad_click',
+                    'occurred_at' => now()->subMinute()->toIso8601String(),
+                    'event_value' => 1,
+                ],
+            ],
+        ]);
+
+        $response->assertCreated();
+
+        $this->assertCount(2, KpiEvent::all());
+    }
+
+    public function test_uninstallation_endpoint_deactivates_device(): void
+    {
+        $deviceUuid = (string) Str::uuid();
+
+        $this->postJson('/api/kpi/devices/register', [
+            'device_uuid' => $deviceUuid,
+            'platform' => 'ios',
+            'app_version' => '1.0.0',
+        ])->assertCreated();
+
+        $this->postJson('/api/kpi/uninstallations', [
+            'device_uuid' => $deviceUuid,
+            'uninstalled_at' => now()->toIso8601String(),
+            'reason' => 'user_choice',
+        ])->assertCreated();
+
+        $device = KpiDevice::firstWhere('device_uuid', $deviceUuid);
+        $this->assertFalse($device->is_active);
+        $this->assertDatabaseHas('kpi_uninstallations', [
+            'kpi_device_id' => $device->id,
+            'reason' => 'user_choice',
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary
- add database tables and Eloquent models to store KPI devices, installations, sessions, uninstallations, and events
- expose KPI tracking API endpoints for device registration, heartbeats, installations, sessions, uninstallations, and analytics events
- add form requests and feature tests covering the new KPI flows

## Testing
- php artisan test --filter=KpiEndpointsTest

------
https://chatgpt.com/codex/tasks/task_e_68e2996c6950832b99ade2420fa197bd